### PR TITLE
Feature/windows xpile 2

### DIFF
--- a/utils/generate-ttl.bat
+++ b/utils/generate-ttl.bat
@@ -1,0 +1,18 @@
+@echo off
+IF NOT EXIST bin GOTO NOBINDIR
+CD bin
+SET GEN=%~dp0\lv2_ttl_generator.exe
+SET EXT=dll
+for /D %%s in (.\*) do (call :generatettls "%%s")
+
+
+goto :eof
+:NOBINDIR
+echo "Please run this script from the surface root"
+goto :eof
+
+:generatettls
+pushd %1
+for %%i in (*_dsp.dll) do %~dp0\lv2_ttl_generator.exe %%i
+popd
+goto :eof

--- a/utils/lv2-ttl-generator/lv2_ttl_generator.c
+++ b/utils/lv2-ttl-generator/lv2_ttl_generator.c
@@ -30,6 +30,7 @@
 
 typedef void (*TTL_Generator_Function)(const char* basename);
 
+#ifdef TTL_GENERATOR_WINDOWS
 void ErrorExit(LPTSTR lpszFunction)
 {
     // Retrieve the system error message for the last-error code

--- a/utils/lv2-ttl-generator/lv2_ttl_generator.c
+++ b/utils/lv2-ttl-generator/lv2_ttl_generator.c
@@ -30,6 +30,39 @@
 
 typedef void (*TTL_Generator_Function)(const char* basename);
 
+void ErrorExit(LPTSTR lpszFunction)
+{
+    // Retrieve the system error message for the last-error code
+
+    LPVOID lpMsgBuf;
+    LPVOID lpDisplayBuf;
+    DWORD dw = GetLastError();
+
+    FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        dw,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPTSTR) &lpMsgBuf,
+        0, NULL );
+
+    // Display the error message and exit the process
+
+    lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
+        (lstrlen((LPCTSTR)lpMsgBuf) + lstrlen((LPCTSTR)lpszFunction) + 40) * sizeof(TCHAR));
+    sprintf((LPTSTR)lpDisplayBuf,
+        TEXT("%s failed with error %d: %s"),
+        lpszFunction, dw, lpMsgBuf);
+    MessageBox(NULL, (LPCTSTR)lpDisplayBuf, TEXT("Error"), MB_OK);
+
+    LocalFree(lpMsgBuf);
+    LocalFree(lpDisplayBuf);
+    ExitProcess(dw);
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     if (argc != 2)


### PR DESCRIPTION
- Added ability to display an error message when trying to open lv2 dlls on Windows (in lv2_ttl_generator).
- Added a windows batch file analogous to generate-ttl.sh
