### PR TITLE
Vst key events

### DIFF
--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -187,6 +187,9 @@ public:
         case  6: index = kCharEscape;    break;
         case 22: index = kCharDelete;    break;
 
+        //Other keycodes
+        case 7:  index = ' '; break;
+
         // handle rest of special keys
         case 40: special = kKeyF1;       break;
         case 41: special = kKeyF2;       break;
@@ -214,7 +217,7 @@ public:
         if (special != 0)
             return fUI.handlePluginSpecial(down, static_cast<Key>(special));
 
-        if (index > 0 || (value == 7 && index == 0))
+        if (index > 0)
             return fUI.handlePluginKeyboard(down, static_cast<uint>(index));
 # endif
 

--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -171,6 +171,7 @@ public:
 
     int handlePluginKeyEvent(const bool down, int32_t index, const intptr_t value)
     {
+# if !DISTRHO_PLUGIN_HAS_EXTERNAL_UI
         d_stdout("handlePluginKeyEvent %i %i %li\n", down, index, (long int)value);
 
         int special = 0;
@@ -215,6 +216,7 @@ public:
 
         if (index > 0 || (value == 7 && index == 0))
             return fUI.handlePluginKeyboard(down, static_cast<uint>(index));
+# endif
 
         return 0;
     }

--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -177,9 +177,9 @@ public:
         switch (value)
         {
         // special casing (can be combined with normal keys)
-        case 54: fUI.handlePluginSpecial(down, kKeyShift);   break;
-        case 55: fUI.handlePluginSpecial(down, kKeyControl); break;
-        case 56: fUI.handlePluginSpecial(down, kKeyAlt);     break;
+        case 54: special = kKeyShift;   break;
+        case 55: special = kKeyControl; break;
+        case 56: special = kKeyAlt;     break;
 
         // convert some specials to normal keys
         case  1: index = kCharBackspace; break;
@@ -213,7 +213,7 @@ public:
         if (special != 0)
             return fUI.handlePluginSpecial(down, static_cast<Key>(special));
 
-        if (index >= 0)
+        if (index > 0 || (value == 7 && index == 0))
             return fUI.handlePluginKeyboard(down, static_cast<uint>(index));
 
         return 0;


### PR DESCRIPTION
- Fixes Ctrl/Shift/Alt event handling
- Fixes build for Zyn's ntk external UI

See also: https://github.com/DISTRHO/DPF/issues/19

For zyn-fusion I've internally implemented a fix for the repeated key presses. With these changes I'd say the vst-key-event handling should be good enough to merge into master, though that's your call in the end.

If nothing else merging these with the DISTRHO/DPF repo should make it easy for me to get out some more builds with the fixes with the build-from-scratch scripts I have.