### PR TITLE
Explicitly state supported LV2 options & use param:sampleRate

### DIFF
--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -719,6 +719,19 @@ public:
                     d_stderr("Host changed sampleRate but with wrong value type");
                 }
             }
+            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_CORE__sampleRate))
+            {
+                if (options[i].type == fURIDs.atomDouble)
+                {
+                    const double sampleRate(*(const double*)options[i].value);
+                    fSampleRate = sampleRate;
+                    fPlugin.setSampleRate(sampleRate);
+                }
+                else
+                {
+                    d_stderr("Host changed sampleRate but with wrong value type");
+                }
+            }
         }
 
         return LV2_OPTIONS_SUCCESS;

--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -719,19 +719,6 @@ public:
                     d_stderr("Host changed sampleRate but with wrong value type");
                 }
             }
-            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_CORE__sampleRate))
-            {
-                if (options[i].type == fURIDs.atomDouble)
-                {
-                    const double sampleRate(*(const double*)options[i].value);
-                    fSampleRate = sampleRate;
-                    fPlugin.setSampleRate(sampleRate);
-                }
-                else
-                {
-                    d_stderr("Host changed sampleRate but with wrong value type");
-                }
-            }
         }
 
         return LV2_OPTIONS_SUCCESS;

--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -23,6 +23,7 @@
 #include "lv2/instance-access.h"
 #include "lv2/midi.h"
 #include "lv2/options.h"
+#include "lv2/parameters.h"
 #include "lv2/state.h"
 #include "lv2/time.h"
 #include "lv2/urid.h"
@@ -685,7 +686,7 @@ public:
             {
                 if (options[i].type == fURIDs.atomInt)
                 {
-                    const int bufferSize(*(const int*)options[i].value);
+                    const int32_t bufferSize(*(const int32_t*)options[i].value);
                     fPlugin.setBufferSize(bufferSize);
                 }
                 else
@@ -697,7 +698,7 @@ public:
             {
                 if (options[i].type == fURIDs.atomInt)
                 {
-                    const int bufferSize(*(const int*)options[i].value);
+                    const int32_t bufferSize(*(const int32_t*)options[i].value);
                     fPlugin.setBufferSize(bufferSize);
                 }
                 else
@@ -705,11 +706,11 @@ public:
                     d_stderr("Host changed maxBlockLength but with wrong value type");
                 }
             }
-            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_CORE__sampleRate))
+            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_PARAMETERS__sampleRate))
             {
-                if (options[i].type == fURIDs.atomDouble)
+                if (options[i].type == fURIDs.atomFloat)
                 {
-                    const double sampleRate(*(const double*)options[i].value);
+                    const float sampleRate(*(const float*)options[i].value);
                     fSampleRate = sampleRate;
                     fPlugin.setSampleRate(sampleRate);
                 }

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -259,7 +259,6 @@ void lv2_generate_ttl(const char* const basename)
         pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ,\n";
         pluginString += "                         <" LV2_BUF_SIZE__maxBlockLength "> ,\n";
         pluginString += "                         <" LV2_PARAMETERS__sampleRate "> ,\n";
-        pluginString += "                         <" LV2_CORE__sampleRate "> ;\n";
         pluginString += "\n";
 
         // UI
@@ -614,8 +613,7 @@ void lv2_generate_ttl(const char* const basename)
         uiString += "    lv2:requiredFeature <" LV2_OPTIONS__options "> ,\n";
         uiString += "                        <" LV2_URID__map "> ;\n";
 
-        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> ,\n";
-        uiString += "    opts:supportedOption <" LV2_CORE__sampleRate "> .";
+        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .\n";
         uiString += "\n\n";
 
         uiFile << uiString << std::endl;

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -256,11 +256,11 @@ void lv2_generate_ttl(const char* const basename)
         pluginString += ";\n\n";
 
         // supportedOptions
-        pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ";
-        pluginString += ",\n                         <" LV2_BUF_SIZE__maxBlockLength "> ";
-        pluginString += ",\n                         <" LV2_PARAMETERS__sampleRate "> ";
-        pluginString += ",\n                         <" LV2_CORE__sampleRate "> ";
-        pluginString += ";\n\n";
+        pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ,\n";
+        pluginString += "                         <" LV2_BUF_SIZE__maxBlockLength "> ,\n";
+        pluginString += "                         <" LV2_PARAMETERS__sampleRate "> ,\n";
+        pluginString += "                         <" LV2_CORE__sampleRate "> ;\n";
+        pluginString += "\n";
 
         // UI
 #if DISTRHO_PLUGIN_HAS_UI

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -255,7 +255,7 @@ void lv2_generate_ttl(const char* const basename)
 #endif
         pluginString += ";\n\n";
 
-        // supportedOption
+        // supportedOptions
         pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ";
         pluginString += ",\n                         <" LV2_BUF_SIZE__maxBlockLength "> ";
         pluginString += ",\n                         <" LV2_PARAMETERS__sampleRate "> ";

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -259,6 +259,7 @@ void lv2_generate_ttl(const char* const basename)
         pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ";
         pluginString += ",\n                         <" LV2_BUF_SIZE__maxBlockLength "> ";
         pluginString += ",\n                         <" LV2_PARAMETERS__sampleRate "> ";
+        pluginString += ",\n                         <" LV2_CORE__sampleRate "> ";
         pluginString += ";\n\n";
 
         // UI
@@ -613,7 +614,8 @@ void lv2_generate_ttl(const char* const basename)
         uiString += "    lv2:requiredFeature <" LV2_OPTIONS__options "> ,\n";
         uiString += "                        <" LV2_URID__map "> ;\n";
 
-        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .";
+        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> ,\n";
+        uiString += "    opts:supportedOption <" LV2_CORE__sampleRate "> .";
         uiString += "\n\n";
 
         uiFile << uiString << std::endl;

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -614,7 +614,6 @@ void lv2_generate_ttl(const char* const basename)
         uiString += "                        <" LV2_URID__map "> ;\n";
 
         uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .\n";
-        uiString += "\n\n";
 
         uiFile << uiString << std::endl;
         uiFile.close();

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -201,6 +201,7 @@ void lv2_generate_ttl(const char* const basename)
 #ifdef DISTRHO_PLUGIN_BRAND
         pluginString += "@prefix mod:  <http://moddevices.com/ns/mod#> .\n";
 #endif
+        pluginString += "@prefix opts: <" LV2_OPTIONS_PREFIX "> .\n";
         pluginString += "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n";
         pluginString += "@prefix rsz:  <" LV2_RESIZE_PORT_PREFIX "> .\n";
 #if DISTRHO_PLUGIN_HAS_UI
@@ -252,6 +253,12 @@ void lv2_generate_ttl(const char* const basename)
 #ifdef DISTRHO_PLUGIN_LICENSED_FOR_MOD
         pluginString += ",\n                        <" MOD_LICENSE__feature "> ";
 #endif
+        pluginString += ";\n\n";
+
+        // supportedOption
+        pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ";
+        pluginString += ",\n                         <" LV2_BUF_SIZE__maxBlockLength "> ";
+        pluginString += ",\n                         <" LV2_PARAMETERS__sampleRate "> ";
         pluginString += ";\n\n";
 
         // UI
@@ -583,8 +590,9 @@ void lv2_generate_ttl(const char* const basename)
         std::fstream uiFile(uiTTL, std::ios::out);
 
         String uiString;
-        uiString += "@prefix lv2: <" LV2_CORE_PREFIX "> .\n";
-        uiString += "@prefix ui:  <" LV2_UI_PREFIX "> .\n";
+        uiString += "@prefix lv2:  <" LV2_CORE_PREFIX "> .\n";
+        uiString += "@prefix ui:   <" LV2_UI_PREFIX "> .\n";
+        uiString += "@prefix opts: <" LV2_OPTIONS_PREFIX "> .\n";
         uiString += "\n";
 
         uiString += "<" DISTRHO_UI_URI ">\n";
@@ -603,7 +611,10 @@ void lv2_generate_ttl(const char* const basename)
         uiString += "\n";
 #  endif
         uiString += "    lv2:requiredFeature <" LV2_OPTIONS__options "> ,\n";
-        uiString += "                        <" LV2_URID__map "> .\n";
+        uiString += "                        <" LV2_URID__map "> ;\n";
+
+        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .";
+        uiString += "\n\n";
 
         uiFile << uiString << std::endl;
         uiFile.close();

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -258,7 +258,7 @@ void lv2_generate_ttl(const char* const basename)
         // supportedOptions
         pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ,\n";
         pluginString += "                         <" LV2_BUF_SIZE__maxBlockLength "> ,\n";
-        pluginString += "                         <" LV2_PARAMETERS__sampleRate "> ,\n";
+        pluginString += "                         <" LV2_PARAMETERS__sampleRate "> ;\n";
         pluginString += "\n";
 
         // UI

--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -190,6 +190,20 @@ public:
                     continue;
                 }
             }
+            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_CORE__sampleRate))
+            {
+                if (options[i].type == fUridMap->map(fUridMap->handle, LV2_ATOM__Double))
+                {
+                    const double sampleRate(*(const double*)options[i].value);
+                    fUI.setSampleRate(sampleRate);
+                    continue;
+                }
+                else
+                {
+                    d_stderr("Host changed sampleRate but with wrong value type");
+                    continue;
+                }
+            }
         }
 
         return LV2_OPTIONS_SUCCESS;

--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -190,20 +190,6 @@ public:
                     continue;
                 }
             }
-            else if (options[i].key == fUridMap->map(fUridMap->handle, LV2_CORE__sampleRate))
-            {
-                if (options[i].type == fUridMap->map(fUridMap->handle, LV2_ATOM__Double))
-                {
-                    const double sampleRate(*(const double*)options[i].value);
-                    fUI.setSampleRate(sampleRate);
-                    continue;
-                }
-                else
-                {
-                    d_stderr("Host changed sampleRate but with wrong value type");
-                    continue;
-                }
-            }
         }
 
         return LV2_OPTIONS_SUCCESS;


### PR DESCRIPTION
Semantically [`lv2:sampleRate`](http://lv2plug.in/ns/lv2core/#sampleRate) is a port property (equivalent to `LADSPA_HINT_SAMPLE_RATE`), not a parameter. Jalv, for example, uses [`param:sampleRate`](http://lv2plug.in/ns/ext/parameters/#sampleRate) with a float value for this purpose. ([See here](https://github.com/drobilla/jalv/blob/5f015f74427e39ca411032f5f42bc969f89cf9fe/src/jalv.c#L1077-L1078))