### PR TITLE
Fix shaky TimeBeat in LV2 plugins

### DIFF
--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -387,7 +387,7 @@ public:
                     if (fLastPositionData.barBeat >= 0.0f)
                     {
                         const double rest = std::fmod(fLastPositionData.barBeat, 1.0f);
-                        fTimePosition.bbt.beat = fLastPositionData.barBeat-rest+1.0;
+                        fTimePosition.bbt.beat = std::round(fLastPositionData.barBeat-rest+1.0);
                         fTimePosition.bbt.tick = rest*fTimePosition.bbt.ticksPerBeat+0.5;
                     }
                 }
@@ -580,7 +580,7 @@ public:
                                                               (double)fLastPositionData.beatsPerBar);
 
                         const double rest = std::fmod(fLastPositionData.barBeat, 1.0f);
-                        fTimePosition.bbt.beat = fLastPositionData.barBeat-rest+1.0;
+                        fTimePosition.bbt.beat = std::round(fLastPositionData.barBeat-rest+1.0);
                         fTimePosition.bbt.tick = rest*fTimePosition.bbt.ticksPerBeat+0.5;
 
                         if (fLastPositionData.bar >= 0)


### PR DESCRIPTION
Seems like the floating point => int32 conversion was causing some issues.

According to @rghvdberg, VST plugins also have that bug, but I've had some trouble reproducing it. 

In Ardour, I've found that the timebeat in the VST build of the "Info" plugin starts causing issues only if I open the "Plugin analysis" pane. It then twitches between 1 and its correct value. It starts working fine as soon as I close the pane. 

I've tested the VST build in other hosts, such as Carla, Renoise and Qtractor. The timebeat was correct.

The Jack build doesn't seem affected.