### PR TITLE
Add support for plugins that want midi input but aren't synths

### DIFF
--- a/distrho/src/DistrhoPluginCarla.cpp
+++ b/distrho/src/DistrhoPluginCarla.cpp
@@ -317,7 +317,7 @@ protected:
         fPlugin.deactivate();
     }
 
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
     void process(float** const inBuffer, float** const outBuffer, const uint32_t frames, const NativeMidiEvent* const midiEvents, const uint32_t midiEventCount) override
     {
         MidiEvent realMidiEvents[midiEventCount];

--- a/distrho/src/DistrhoPluginInternal.hpp
+++ b/distrho/src/DistrhoPluginInternal.hpp
@@ -503,7 +503,7 @@ public:
         }
     }
 
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
     void run(const float** const inputs, float** const outputs, const uint32_t frames,
              const MidiEvent* const midiEvents, const uint32_t midiEventCount)
     {

--- a/distrho/src/DistrhoPluginJack.cpp
+++ b/distrho/src/DistrhoPluginJack.cpp
@@ -332,7 +332,7 @@ protected:
 
         if (const uint32_t eventCount = jack_midi_get_event_count(midiBuf))
         {
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
             uint32_t  midiEventCount = 0;
             MidiEvent midiEvents[eventCount];
 #endif
@@ -383,7 +383,7 @@ protected:
                 }
 #endif
 
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
                 MidiEvent& midiEvent(midiEvents[midiEventCount++]);
 
                 midiEvent.frame = jevent.time;
@@ -396,11 +396,11 @@ protected:
 #endif
             }
 
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
             fPlugin.run(audioIns, audioOuts, nframes, midiEvents, midiEventCount);
 #endif
         }
-#if DISTRHO_PLUGIN_IS_SYNTH
+#if DISTRHO_PLUGIN_WANT_MIDI_INPUT
         else
         {
             fPlugin.run(audioIns, audioOuts, nframes, nullptr, 0);


### PR DESCRIPTION
Plugins with DISTRHO_PLUGIN_WANT_MIDI_INPUT set to true and DISTRHO_PLUGIN_IS_SYNTH set to false would get the wrong run() method definition.

Is this fix correct?