### PR TITLE
Handle paths with spaces when generating ttl

### DIFF
--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -9,13 +9,13 @@ else
   exit
 fi
 
-PWD=`dirname $0`
+PWD="$(dirname "$0")"
 
-if [ -f $PWD/lv2_ttl_generator.exe ]; then
-  GEN=$PWD/lv2_ttl_generator.exe
+if [ -f "$PWD/lv2_ttl_generator.exe" ]; then
+  GEN="$PWD/lv2_ttl_generator.exe"
   EXT=dll
 else
-  GEN=$PWD/lv2_ttl_generator
+  GEN="$PWD/lv2_ttl_generator"
   if [ -d /Library/Audio ]; then
     EXT=dylib
   else
@@ -27,7 +27,7 @@ FOLDERS=`find . -type d -name \*.lv2`
 
 for i in $FOLDERS; do
   cd $i
-  FILE=`ls *.$EXT | sort | head -n 1`
-  $GEN ./$FILE
+  FILE="$(ls *.$EXT | sort | head -n 1)"
+  "$GEN" "./$FILE"
   cd ..
 done


### PR DESCRIPTION
The script would fail with a ```binary operator expected``` error at line 14.

Does this fix make sense? My bash skills are pretty abysmal :)

Also, the default Makefile for DPF plugins fails at gen if the path contains spaces due to an unquoted CURDIR: https://github.com/zamaudio/zam-plugins/blob/master/Makefile#L22