### PR TITLE
Support GNU platforms other than Linux

### DIFF
--- a/distrho/src/DistrhoDefines.h
+++ b/distrho/src/DistrhoDefines.h
@@ -37,7 +37,7 @@
 #  define DISTRHO_DLL_EXTENSION "dylib"
 # elif defined(__HAIKU__)
 #  define DISTRHO_OS_HAIKU      1
-# elif defined(__linux__) || defined(__linux)
+# elif defined(__linux__) || defined(__linux) || defined(__GLIBC__)
 #  define DISTRHO_OS_LINUX 1
 # endif
 #endif


### PR DESCRIPTION
Treat all glibc-based platforms as DISTRHO_OS_LINUX, even those not
based on Linux such as GNU/kFreeBSD or GNU/Hurd.

Also, wrap ifdefs around sa_restorer which really is specific to (some)
Linux platforms.  (A feature-test macro would be better, though it is
obsolete and maybe should be removed altogether...)