### PR TITLE
Allow negative scaling of NanoVG context

### DIFF
--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -472,9 +472,7 @@ void NanoVG::skewY(float angle)
 void NanoVG::scale(float x, float y)
 {
     if (fContext == nullptr) return;
-    DISTRHO_SAFE_ASSERT_RETURN(x > 0.0f,);
-    DISTRHO_SAFE_ASSERT_RETURN(y > 0.0f,);
-
+    
     nvgScale(fContext, x, y);
 }
 


### PR DESCRIPTION
Negative scaling can be used for flipping an axis.