### PR TITLE
Return proper bounds in NanoVG::textBounds

### DIFF
--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -865,7 +865,7 @@ float NanoVG::textBounds(float x, float y, const char* string, const char* end, 
 
     float b[4];
     const float ret = nvgTextBounds(fContext, x, y, string, end, b);
-    bounds = Rectangle<float>(b[0], b[1], b[2], b[3]);
+    bounds = Rectangle<float>(b[0], b[1], b[2] - b[0], b[3] - b[1]);
     return ret;
 }
 


### PR DESCRIPTION
From the NanoVG header at https://github.com/DISTRHO/DPF/blob/master/dgl/src/nanovg/nanovg.h#L527 : 
```
The bounds value are [xmin,ymin, xmax,ymax]
```

Thus, b[2] - b[0] to get the width, b[3] - b[1] to get the height.