### PR TITLE
Add onPositionChanged callback for widgets

### DIFF
--- a/dgl/Widget.hpp
+++ b/dgl/Widget.hpp
@@ -176,6 +176,22 @@ public:
     };
 
    /**
+      Widget position changed event.
+      @a pos    The new absolute position of the widget.
+      @a oldPos The previous absolute position of the widget.
+      @see onPositionChanged
+    */
+    struct PositionChangedEvent {
+        Point<int> pos;
+        Point<int> oldPos;
+
+        /** Constuctor */
+        PositionChangedEvent() noexcept
+            : pos(0, 0),
+              oldPos(0, 0) {}
+    };
+
+   /**
       Constructor.
     */
     explicit Widget(Window& parent);
@@ -361,6 +377,11 @@ protected:
       A function called when the widget is resized.
     */
     virtual void onResize(const ResizeEvent&);
+
+   /**
+      A function called when the widget's absolute position is changed.
+    */
+    virtual void onPositionChanged(const PositionChangedEvent&);
 
 private:
     struct PrivateData;

--- a/dgl/src/Widget.cpp
+++ b/dgl/src/Widget.cpp
@@ -151,20 +151,12 @@ const Point<int>& Widget::getAbsolutePos() const noexcept
 
 void Widget::setAbsoluteX(int x) noexcept
 {
-    if (pData->absolutePos.getX() == x)
-        return;
-
-    pData->absolutePos.setX(x);
-    pData->parent.repaint();
+    setAbsolutePos(Point<int>(x, getAbsoluteY()));
 }
 
 void Widget::setAbsoluteY(int y) noexcept
 {
-    if (pData->absolutePos.getY() == y)
-        return;
-
-    pData->absolutePos.setY(y);
-    pData->parent.repaint();
+    setAbsolutePos(Point<int>(getAbsoluteX(), y));
 }
 
 void Widget::setAbsolutePos(int x, int y) noexcept
@@ -177,7 +169,13 @@ void Widget::setAbsolutePos(const Point<int>& pos) noexcept
     if (pData->absolutePos == pos)
         return;
 
+    PositionChangedEvent ev;
+    ev.oldPos = pData->absolutePos;
+    ev.pos = pos;
+
     pData->absolutePos = pos;
+    onPositionChanged(ev);
+
     pData->parent.repaint();
 }
 
@@ -242,6 +240,10 @@ bool Widget::onScroll(const ScrollEvent&)
 }
 
 void Widget::onResize(const ResizeEvent&)
+{
+}
+
+void Widget::onPositionChanged(const PositionChangedEvent&)
 {
 }
 


### PR DESCRIPTION
This is useful for container widgets. Simple example:
```c++
void ParentWidget::onPositionChanged(const PositionChangedEvent &ev)
{
    fSubWidget->setAbsolutePos(ev.pos); //the subwidget moves with the parent
}
```