### PR TITLE
Tweak behaviour of NanoWidget as subwidget of another NanoWidget

### DIFF
--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -948,7 +948,7 @@ NanoWidget::NanoWidget(NanoWidget* groupWidget)
       nData(new PrivateData(this))
 {
     pData->needsScaling = true;
-    pData->skipDisplay = true;
+    pData->skipDisplay = false;
     groupWidget->nData->subWidgets.push_back(this);
 }
 
@@ -960,13 +960,8 @@ NanoWidget::~NanoWidget()
 void NanoWidget::onDisplay()
 {
     NanoVG::beginFrame(getWidth(), getHeight());
-    onNanoDisplay();
 
-    for (std::vector<NanoWidget*>::iterator it = nData->subWidgets.begin(); it != nData->subWidgets.end(); ++it)
-    {
-        NanoWidget* const widget(*it);
-        widget->onNanoDisplay();
-    }
+    onNanoDisplay();
 
     NanoVG::endFrame();
 }


### PR DESCRIPTION
This would fix the weird behavior I've described in https://github.com/DISTRHO/DPF/issues/68. 

I really don't know if this is a proper fix, but it works with Wolf Shaper and the rectangles example I've shown in the issue. 

It makes the subwidgets pass through this OpenGL code, which sets the correct viewport: https://github.com/DISTRHO/DPF/blob/6d35b690e5399ceaf52b42443b0b3a94587122ac/dgl/src/WidgetPrivateData.hpp#L81-L88

So, calling `rect(0, 0, getWidth(), getHeight());` should draw a rectangle equal to the widget's viewport.

Also, in onNanoDisplay(), you can freely use NanoVG's translate(), reset(), etc. It doesn't seem to affect the OpenGL viewport.