### PR TITLE
Fix compilation of files with directories in their path

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -77,12 +77,12 @@ all:
 # Common
 
 $(BUILD_DIR)/%.c.o: %.c
-	-@mkdir -p $(BUILD_DIR)
+	-@mkdir -p "$(BUILD_DIR)/$(shell dirname $<)"
 	@echo "Compiling $<"
 	@$(CC) $< $(BUILD_C_FLAGS) -c -o $@
 
 $(BUILD_DIR)/%.cpp.o: %.cpp
-	-@mkdir -p $(BUILD_DIR)
+	-@mkdir -p "$(BUILD_DIR)/$(shell dirname $<)"
 	@echo "Compiling $<"
 	@$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@
 


### PR DESCRIPTION
My FILES_DSP and FILES_UI contained directories in their path, which lead to this kind of errors at build:
```
make[1]: Entering directory '/home/spoonie/dsp/wolf-shaper/plugins/wolf-shaper'
Compiling Common/Utils/src/Mathf.cpp
Assembler messages:
Fatal error: can't create ../../build/wolf-shaper/Common/Utils/src/Mathf.cpp.o: No such file or directory
make[1]: *** [../../dpf/Makefile.plugins.mk:87: ../../build/wolf-shaper/Common/Utils/src/Mathf.cpp.o] Error 2
make[1]: Leaving directory '/home/spoonie/dsp/wolf-shaper/plugins/wolf-shaper'
make: *** [Makefile:40: plugins] Error 2
```
I fixed this by creating folders up to the file to compile.

You can test this issue with ZamSFZ. However, I needed to add flags for libsamplerate in order to get it to build:
```diff
-    BASE_FLAGS += $(shell pkg-config --cflags sndfile rubberband)
-    LINK_FLAGS += $(shell pkg-config --libs sndfile rubberband)
+    BASE_FLAGS += $(shell pkg-config --cflags sndfile rubberband samplerate)
+    LINK_FLAGS += $(shell pkg-config --libs sndfile rubberband samplerate)
```

The other zam-plugins seem to build fine with this commit.