### PR TITLE
Allow negative rotation angle in NanoVG

### DIFF
--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -447,10 +447,8 @@ void NanoVG::translate(float x, float y)
 
 void NanoVG::rotate(float angle)
 {
-    if (fContext == nullptr) return;
-    DISTRHO_SAFE_ASSERT_RETURN(angle > 0.0f,);
-
-    nvgRotate(fContext, angle);
+    if (fContext != nullptr)
+        nvgRotate(fContext, angle);
 }
 
 void NanoVG::skewX(float angle)


### PR DESCRIPTION
If I have to rotate a shape counterclockwise by a certain amount of degrees, I would do
```c++
rotate(degToRad(-degrees));
```
This seems to work as expected. I'm pretty sure it's a valid operation.