### PR TITLE
Fix ttl generation for plugins that use events out but not events in

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -192,7 +192,7 @@ void lv2_generate_ttl(const char* const basename)
         String pluginString;
 
         // header
-#if DISTRHO_LV2_USE_EVENTS_IN
+#if DISTRHO_LV2_USE_EVENTS_IN || DISTRHO_LV2_USE_EVENTS_OUT
         pluginString += "@prefix atom: <" LV2_ATOM_PREFIX "> .\n";
 #endif
         pluginString += "@prefix doap: <http://usefulinc.com/ns/doap#> .\n";


### PR DESCRIPTION
The atom prefix is necessary when the plugin uses events out, so we need to include it: https://github.com/DISTRHO/DPF/blob/master/distrho/src/DistrhoPluginLV2export.cpp#L357

Without the fix in this pull request, the plugin would fail to load in Carla.