### PR TITLE
Fix some parts of BarBeatTick documentation

### DIFF
--- a/distrho/DistrhoPlugin.hpp
+++ b/distrho/DistrhoPlugin.hpp
@@ -546,7 +546,7 @@ struct TimePosition {
 
        /**
           Current tick within beat.@n
-          Should always be > 0 and <= @a ticksPerBeat.@n
+          Should always be >= 0 and < @a ticksPerBeat.@n
           The first tick is tick '0'.
         */
         int32_t tick;
@@ -567,7 +567,7 @@ struct TimePosition {
         float beatType;
 
        /**
-          Number of ticks within a bar.@n
+          Number of ticks within a beat.@n
           Usually a moderately large integer with many denominators, such as 1920.0.
         */
         double ticksPerBeat;


### PR DESCRIPTION
I think these errors were copied from the jack docs: http://jackaudio.org/files/docs/html/structjack__position__t.html#a9ba36f6c4eaede3bb1c9b7a85b5f76d1