### PR TITLE
Fix some warnings as well as a bug in DSSI

### DIFF
--- a/distrho/DistrhoPlugin.hpp
+++ b/distrho/DistrhoPlugin.hpp
@@ -590,6 +590,22 @@ struct TimePosition {
               beatType(0.0f),
               ticksPerBeat(0.0),
               beatsPerMinute(0.0) {}
+
+       /**
+          Reinitialize this position using the default null initialization.
+        */
+        void clear() noexcept
+        {
+            valid = false;
+            bar = 0;
+            beat = 0;
+            tick = 0;
+            barStartTick = 0.0;
+            beatsPerBar = 0.0f;
+            beatType = 0.0f;
+            ticksPerBeat = 0.0;
+            beatsPerMinute = 0.0;
+        }
     } bbt;
 
    /**
@@ -599,6 +615,16 @@ struct TimePosition {
         : playing(false),
           frame(0),
           bbt() {}
+
+   /**
+      Reinitialize this position using the default null initialization.
+    */
+    void clear() noexcept
+    {
+        playing  = false;
+        frame = 0;
+        bbt.clear();
+    }
 };
 
 /** @} */

--- a/distrho/src/DistrhoPluginLADSPA+DSSI.cpp
+++ b/distrho/src/DistrhoPluginLADSPA+DSSI.cpp
@@ -286,9 +286,9 @@ public:
 # if DISTRHO_PLUGIN_WANT_STATE
     char* dssi_configure(const char* const key, const char* const value)
     {
-        if (std::strncmp(key, DSSI_RESERVED_CONFIGURE_PREFIX, std::strlen(DSSI_RESERVED_CONFIGURE_PREFIX) == 0))
+        if (std::strncmp(key, DSSI_RESERVED_CONFIGURE_PREFIX, std::strlen(DSSI_RESERVED_CONFIGURE_PREFIX)) == 0)
             return nullptr;
-        if (std::strncmp(key, DSSI_GLOBAL_CONFIGURE_PREFIX, std::strlen(DSSI_GLOBAL_CONFIGURE_PREFIX) == 0))
+        if (std::strncmp(key, DSSI_GLOBAL_CONFIGURE_PREFIX, std::strlen(DSSI_GLOBAL_CONFIGURE_PREFIX)) == 0)
             return nullptr;
 
         fPlugin.setState(key, value);

--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -169,7 +169,7 @@ public:
     void lv2_activate()
     {
 #if DISTRHO_PLUGIN_WANT_TIMEPOS
-        std::memset(&fTimePosition, 0, sizeof(TimePosition));
+        fTimePosition.clear();
 
         // hosts may not send all values, resulting on some invalid data
         fTimePosition.bbt.bar   = 1;

--- a/distrho/src/lv2/atom-util.h
+++ b/distrho/src/lv2/atom-util.h
@@ -117,13 +117,13 @@ lv2_atom_sequence_next(const LV2_Atom_Event* i)
    @endcode
 */
 #define LV2_ATOM_SEQUENCE_FOREACH(seq, iter) \
-	for (const LV2_Atom_Event* (iter) = lv2_atom_sequence_begin(&(seq)->body); \
+	for (const LV2_Atom_Event* iter = lv2_atom_sequence_begin(&(seq)->body); \
 	     !lv2_atom_sequence_is_end(&(seq)->body, (seq)->atom.size, (iter)); \
 	     (iter) = lv2_atom_sequence_next(iter))
 
 /** Like LV2_ATOM_SEQUENCE_FOREACH but for a headerless sequence body. */
 #define LV2_ATOM_SEQUENCE_BODY_FOREACH(body, size, iter) \
-	for (const LV2_Atom_Event* (iter) = lv2_atom_sequence_begin(body); \
+	for (const LV2_Atom_Event* iter = lv2_atom_sequence_begin(body); \
 	     !lv2_atom_sequence_is_end(body, size, (iter)); \
 	     (iter) = lv2_atom_sequence_next(iter))
 
@@ -214,13 +214,13 @@ lv2_atom_tuple_next(const LV2_Atom* i)
    @endcode
 */
 #define LV2_ATOM_TUPLE_FOREACH(tuple, iter) \
-	for (const LV2_Atom* (iter) = lv2_atom_tuple_begin(tuple); \
+	for (const LV2_Atom* iter = lv2_atom_tuple_begin(tuple); \
 	     !lv2_atom_tuple_is_end(LV2_ATOM_BODY_CONST(tuple), (tuple)->size, (iter)); \
 	     (iter) = lv2_atom_tuple_next(iter))
 
 /** Like LV2_ATOM_TUPLE_FOREACH but for a headerless tuple body. */
 #define LV2_ATOM_TUPLE_BODY_FOREACH(body, size, iter) \
-	for (const LV2_Atom* (iter) = (const LV2_Atom*)body; \
+	for (const LV2_Atom* iter = (const LV2_Atom*)body; \
 	     !lv2_atom_tuple_is_end(body, size, (iter)); \
 	     (iter) = lv2_atom_tuple_next(iter))
 
@@ -270,13 +270,13 @@ lv2_atom_object_next(const LV2_Atom_Property_Body* i)
    @endcode
 */
 #define LV2_ATOM_OBJECT_FOREACH(obj, iter) \
-	for (const LV2_Atom_Property_Body* (iter) = lv2_atom_object_begin(&(obj)->body); \
+	for (const LV2_Atom_Property_Body* iter = lv2_atom_object_begin(&(obj)->body); \
 	     !lv2_atom_object_is_end(&(obj)->body, (obj)->atom.size, (iter)); \
 	     (iter) = lv2_atom_object_next(iter))
 
 /** Like LV2_ATOM_OBJECT_FOREACH but for a headerless object body. */
 #define LV2_ATOM_OBJECT_BODY_FOREACH(body, size, iter) \
-	for (const LV2_Atom_Property_Body* (iter) = lv2_atom_object_begin(body); \
+	for (const LV2_Atom_Property_Body* iter = lv2_atom_object_begin(body); \
 	     !lv2_atom_object_is_end(body, size, (iter)); \
 	     (iter) = lv2_atom_object_next(iter))
 

--- a/examples/Meters/ExampleUIMeters.cpp
+++ b/examples/Meters/ExampleUIMeters.cpp
@@ -93,7 +93,7 @@ protected:
       A state has changed on the plugin side.
       This is called by the host to inform the UI about state changes.
     */
-    void stateChanged(const char*, const char*)
+    void stateChanged(const char*, const char*) override
     {
         // nothing here
     }


### PR DESCRIPTION
Some warnings fixed
`-Wclass-memaccess`
`-Wparentheses`
`-Winconsistent-missing-override`
`-Wmemsize-comparison`

About the latter, it is a bug detected in DSSI about a misplaced parenthesis.
It will cause the comparison of prefix to work incorrectly.