### PR TITLE
png2rgba: Support palette-based PNG files

### DIFF
--- a/utils/png2rgba.py
+++ b/utils/png2rgba.py
@@ -52,7 +52,10 @@ def png2rgba(namespace, filenames):
         shortFilename = filename.rsplit(os.sep, 1)[-1].split(".", 1)[0]
         shortFilename = shortFilename.replace("-", "_")
 
-        png      = Image.open(filename)
+        png = Image.open(filename)
+        if png.getpalette():
+            png = png.convert()
+
         pngNumpy = numpy.array(png)
         pngData  = pngNumpy.tolist()
         #pngData.reverse()


### PR DESCRIPTION
#127 

This is to support palette-based PNG files.
It converts to an intermediate RGBA picture.