### PR TITLE
Fix a build failure with parallel make

### DIFF
--- a/dgl/Makefile
+++ b/dgl/Makefile
@@ -89,7 +89,7 @@ all: $(TARGETS)
 # Compat name, to be removed soon
 ../build/libdgl.a: ../build/libdgl-opengl.a
 	@echo "Symlinking libdgl.a"
-	@ln -s $< $@
+	@ln -sf $< $@
 
 # ---------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
When DPF is built once, and then rebuilt with "-j4", this error may occur.

```
Compiling src/OpenGL.cpp (OpenGL variant)
Creating libdgl-opengl.a
Symlinking libdgl.a
ln: failed to create symbolic link '../build/libdgl.a': File exists
```

I can reproduce it every time with `touch dgl/src/OpenGL.cpp` and then `make -j4`.
For some reason, it never occurs on "-j1"; the symlink rule is not invoked when it's on a single make job.