### PR TITLE
Fix invalid atom size on sendNote (LV2)

### DIFF
--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -286,7 +286,7 @@ protected:
         atomMidiEvent.data[2] = velocity;
 
         // send to DSP side
-        fWriteFunction(fController, eventInPortIndex, sizeof(LV2_Atom_MidiEvent), fEventTransferURID, &atomMidiEvent);
+        fWriteFunction(fController, eventInPortIndex, lv2_atom_total_size(&atomMidiEvent.atom), fEventTransferURID, &atomMidiEvent);
     }
 #endif
 


### PR DESCRIPTION
Carla would complain about the following on sendNote:
```
Warning: LV2 UI sending atom with invalid size! size: 11, padded-size: 16
```
Assuming that this is not a bug in Carla, this seems like a proper fix? 

It looks like sizeof(LV2_Atom_MidiEvent) would add 1 byte of padding (12 bytes instead of 11 bytes), which would lead to this warning. Adding `__attribute__((packed))` to the struct also makes the warning disappear.