### PR TITLE
Fix LV2 state string exporting

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -719,7 +719,7 @@ void lv2_generate_ttl(const char* const basename)
                 if (value.length() < 10)
                     presetString += " \"" + value + "\" ;\n";
                 else
-                    presetString += "\n\"\"\"\n" + value + "\n\"\"\" ;\n";
+                    presetString += "\n\"\"\"" + value + "\"\"\" ;\n";
             }
 
             if (numParameters > 0)


### PR DESCRIPTION
The LV2 exporter does not preserve the newlines in state strings.

If the string matches the condition to be considered long (> 10 chars), newlines are inserted before and after, and the string is not preserved as desired.