### PR TITLE
Set UTF8 window title using NetWM hints

### DIFF
--- a/dgl/src/Window.cpp
+++ b/dgl/src/Window.cpp
@@ -687,6 +687,9 @@ struct Window::PrivateData {
         }
 #else
         XStoreName(xDisplay, xWindow, title);
+        Atom netWmName = XInternAtom(xDisplay, "_NET_WM_NAME", False);
+        Atom utf8String = XInternAtom(xDisplay, "UTF8_STRING", False);
+        XChangeProperty(xDisplay, xWindow, netWmName, utf8String, 8, PropModeReplace, (unsigned char *)title, strlen(title));
 #endif
     }
 

--- a/dgl/src/pugl/pugl_x11.c
+++ b/dgl/src/pugl/pugl_x11.c
@@ -274,6 +274,9 @@ puglCreateWindow(PuglView* view, const char* title)
 
 	if (title) {
 		XStoreName(impl->display, impl->win, title);
+		Atom netWmName = XInternAtom(impl->display, "_NET_WM_NAME", False);
+		Atom utf8String = XInternAtom(impl->display, "UTF8_STRING", False);
+		XChangeProperty(impl->display, impl->win, netWmName, utf8String, 8, PropModeReplace, (unsigned char *)title, strlen(title));
 	}
 
 	if (view->transient_parent > 0) {


### PR DESCRIPTION
Set the title with `_NET_WM_NAME` because `XStoreName` cannot handle UTF-8.