### PR TITLE
cairo: define geometry functions, fixes debug link

### DIFF
--- a/dgl/src/Cairo.cpp
+++ b/dgl/src/Cairo.cpp
@@ -14,13 +14,98 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../Base.hpp"
+#include "../Geometry.hpp"
+#include "../Cairo.hpp"
 
 START_NAMESPACE_DGL
 
 // -----------------------------------------------------------------------
 
-// nothing here yet
+static void notImplemented(const char *name)
+{
+    d_stderr2("cairo function not implemented: %s", name);
+}
+
+// -----------------------------------------------------------------------
+// Line
+
+template<typename T>
+void Line<T>::draw()
+{
+    notImplemented("Line::draw");
+}
+
+// -----------------------------------------------------------------------
+// Circle
+
+template<typename T>
+void Circle<T>::_draw(const bool outline)
+{
+    notImplemented("Circle::draw");
+}
+
+// -----------------------------------------------------------------------
+// Triangle
+
+template<typename T>
+void Triangle<T>::_draw(const bool outline)
+{
+    notImplemented("Triangle::draw");
+}
+
+// -----------------------------------------------------------------------
+// Rectangle
+
+template<typename T>
+void Rectangle<T>::_draw(const bool outline)
+{
+    notImplemented("Rectangle::draw");
+}
+
+// -----------------------------------------------------------------------
+// Possible template data types
+
+template class Point<double>;
+template class Point<float>;
+template class Point<int>;
+template class Point<uint>;
+template class Point<short>;
+template class Point<ushort>;
+
+template class Size<double>;
+template class Size<float>;
+template class Size<int>;
+template class Size<uint>;
+template class Size<short>;
+template class Size<ushort>;
+
+template class Line<double>;
+template class Line<float>;
+template class Line<int>;
+template class Line<uint>;
+template class Line<short>;
+template class Line<ushort>;
+
+template class Circle<double>;
+template class Circle<float>;
+template class Circle<int>;
+template class Circle<uint>;
+template class Circle<short>;
+template class Circle<ushort>;
+
+template class Triangle<double>;
+template class Triangle<float>;
+template class Triangle<int>;
+template class Triangle<uint>;
+template class Triangle<short>;
+template class Triangle<ushort>;
+
+template class Rectangle<double>;
+template class Rectangle<float>;
+template class Rectangle<int>;
+template class Rectangle<uint>;
+template class Rectangle<short>;
+template class Rectangle<ushort>;
 
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Using the cairo UI type, I found the following problem can be met:
(possibly a matter of recent compilers)

- only under the case DEBUG=true, the linking stage can end in error when functions are declared and not defined. It's the case of drawing functions from Geometry which don't have implementation.

This problem can be verified on DPF's own CairoUI example.

The patch provides dummy implementation of these functions.