### PR TITLE
add file dialog for macOS

### DIFF
--- a/dgl/src/Window.cpp
+++ b/dgl/src/Window.cpp
@@ -1,6 +1,8 @@
 /*
  * DISTRHO Plugin Framework (DPF)
  * Copyright (C) 2012-2019 Filipe Coelho <falktx@falktx.com>
+ * Copyright (C) 2019 Jean Pierre Cimalando <jp-dev@inbox.ru>
+ * Copyright (C) 2019 Robin Gareus <robin@gareus.org>
  *
  * Permission to use, copy, modify, and/or distribute this software for any purpose with
  * or without fee is hereby granted, provided that the above copyright notice and this

--- a/dgl/src/Window.cpp
+++ b/dgl/src/Window.cpp
@@ -1387,19 +1387,19 @@ bool Window::openFileBrowser(const FileBrowserOptions& options)
     {
         if (result == NSFileHandlingPanelOKButton)
         {
-            NSArray *urls = [panel URLs];
-            NSURL *fileUrl = nullptr;
+            NSArray* urls = [panel URLs];
+            NSURL* fileUrl = nullptr;
 
             for (NSUInteger i = 0, n = [urls count]; i < n && !fileUrl; ++i)
             {
-                NSURL *url = (NSURL *)[urls objectAtIndex:i];
+                NSURL* url = (NSURL*)[urls objectAtIndex:i];
                 if ([url isFileURL])
                     fileUrl = url;
             }
 
             if (fileUrl)
             {
-                PuglView *view = pData->fView;
+                PuglView* view = pData->fView;
                 if (view->fileSelectedFunc)
                 {
                     const char* fileName = [fileUrl.path UTF8String];

--- a/dgl/src/Window.cpp
+++ b/dgl/src/Window.cpp
@@ -1387,18 +1387,24 @@ bool Window::openFileBrowser(const FileBrowserOptions& options)
     {
         if (result == NSFileHandlingPanelOKButton)
         {
-            for (NSURL* url in [panel URLs])
-            {
-                if (![url isFileURL])
-                    continue;
+            NSArray *urls = [panel URLs];
+            NSURL *fileUrl = nullptr;
 
+            for (NSUInteger i = 0, n = [urls count]; i < n && !fileUrl; ++i)
+            {
+                NSURL *url = (NSURL *)[urls objectAtIndex:i];
+                if ([url isFileURL])
+                    fileUrl = url;
+            }
+
+            if (fileUrl)
+            {
                 PuglView *view = pData->fView;
                 if (view->fileSelectedFunc)
                 {
-                    const char* fileName = [url.path UTF8String];
+                    const char* fileName = [fileUrl.path UTF8String];
                     view->fileSelectedFunc(view, fileName);
                 }
-                break;
             }
         }
 

--- a/dgl/src/Window.cpp
+++ b/dgl/src/Window.cpp
@@ -1372,12 +1372,7 @@ bool Window::openFileBrowser(const FileBrowserOptions& options)
     [panel setAllowsMultipleSelection:NO];
 
     if (options.startDir)
-    {
-        NSString *startDirString = [NSString stringWithUTF8String:options.startDir];
-        NSURL *startDirURL = [NSURL fileURLWithPath:startDirString
-                                        isDirectory:YES];
-        [panel setDirectoryURL:startDirURL];
-    }
+        [panel setDirectory:[NSString stringWithUTF8String:options.startDir]];
 
     if (options.title)
     {


### PR DESCRIPTION
This is a Mac version of the file dialog.
It's async, vastly inspired from [puglOpenFileDialog](https://github.com/x42/robtk/blob/master/pugl/pugl_osx.m#L527-L564).
Tried in Juce AudioPluginHost.

Some notes:
- it's guarded against having multiple dialogs at once
- when UI is closed with the file dialog unanswered, it stays. (benign probably)