### PR TITLE
Fix macOS crash on editor closed and reopened

### DIFF
--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -588,7 +588,8 @@ public:
             return 1;
 
         case effEditOpen:
-            if (fVstUI == nullptr)
+            delete fVstUI; // hosts which don't pair effEditOpen/effEditClose calls (Minihost Modular)
+            fVstUI = nullptr;
             {
 # if DISTRHO_OS_MAC
                 if (! fUsingNsView)


### PR DESCRIPTION
On Minihost Modular, the window will not be recreated correctly after
closing. It's because the host does not send the effEditClose opcode.

When effEditOpen is reentered, fVstUI!=nullptr would short-circuit the
initialization of the editor, and continue without an existing window.

----
#153
Tried on Minihost Modular. (crossing fingers this doesn't break anything else.)
@ARival can you check other hosts?