### PR TITLE
Fix crashes in case of absent openGL

### DIFF
--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -81,11 +81,8 @@ static NVGcontext* nvgCreateGL_helper(int flags)
 {
 #if defined(DISTRHO_OS_WINDOWS)
     static bool needsInit = true;
-    if (needsInit)
-    {
-        needsInit = false;
 # define DGL_EXT(PROC, func) \
-      func = (PROC) wglGetProcAddress ( #func ); \
+      if (needsInit) func = (PROC) wglGetProcAddress ( #func ); \
       DISTRHO_SAFE_ASSERT_RETURN(func != nullptr, nullptr);
 DGL_EXT(PFNGLACTIVETEXTUREPROC,            glActiveTexture)
 DGL_EXT(PFNGLATTACHSHADERPROC,             glAttachShader)
@@ -115,7 +112,7 @@ DGL_EXT(PFNGLUNIFORM4FVPROC,               glUniform4fv)
 DGL_EXT(PFNGLUSEPROGRAMPROC,               glUseProgram)
 DGL_EXT(PFNGLVERTEXATTRIBPOINTERPROC,      glVertexAttribPointer)
 # undef DGL_EXT
-    }
+    needsInit = false;
 #endif
     return nvgCreateGL(flags);
 }

--- a/dgl/src/NanoVG.cpp
+++ b/dgl/src/NanoVG.cpp
@@ -918,6 +918,8 @@ int NanoVG::textBreakLines(const char* string, const char* end, float breakRowWi
 #ifndef DGL_NO_SHARED_RESOURCES
 void NanoVG::loadSharedResources()
 {
+    if (fContext == nullptr) return;
+
     if (nvgFindFont(fContext, NANOVG_DEJAVU_SANS_TTF) >= 0)
         return;
 


### PR DESCRIPTION
- checks context nullity at entry of a NanoVG function where it's forgotten
- on openGL context initialization after the first one, the function pointers would not be checked for null, resulting in crash