### PR TITLE
Resolve all the lv2lint issues

### DIFF
--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -846,6 +846,14 @@ public:
 
         return LV2_WORKER_SUCCESS;
     }
+
+    LV2_Worker_Status lv2_work_response(uint32_t size, const void* body)
+    {
+        (void)size;
+        (void)body;
+
+        return LV2_WORKER_SUCCESS;
+    }
 #endif
 
     // -------------------------------------------------------------------
@@ -1243,6 +1251,11 @@ LV2_Worker_Status lv2_work(LV2_Handle instance, LV2_Worker_Respond_Function, LV2
 {
     return instancePtr->lv2_work(data);
 }
+
+LV2_Worker_Status lv2_work_response(LV2_Handle instance, uint32_t size, const void* body)
+{
+    return instancePtr->lv2_work_response(size, body);
+}
 #endif
 
 // -----------------------------------------------------------------------
@@ -1272,7 +1285,7 @@ static const void* lv2_extension_data(const char* uri)
 
 #if DISTRHO_PLUGIN_WANT_STATE
     static const LV2_State_Interface state = { lv2_save, lv2_restore };
-    static const LV2_Worker_Interface worker = { lv2_work, nullptr, nullptr };
+    static const LV2_Worker_Interface worker = { lv2_work, lv2_work_response, nullptr };
 
     if (std::strcmp(uri, LV2_STATE__interface) == 0)
         return &state;

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -73,9 +73,9 @@
 // -----------------------------------------------------------------------
 static const char *const lv2ManifestPluginExtensionData[] =
 {
-    LV2_STATE__interface,
-#if DISTRHO_PLUGIN_WANT_STATE
     LV2_OPTIONS__interface,
+#if DISTRHO_PLUGIN_WANT_STATE
+    LV2_STATE__interface,
     LV2_WORKER__interface,
 #endif
 #if DISTRHO_PLUGIN_WANT_PROGRAMS
@@ -120,10 +120,12 @@ static const char *const lv2ManifestPluginSupportedOptions[] =
 #if DISTRHO_PLUGIN_HAS_UI
 static const char *const lv2ManifestUiExtensionData[] =
 {
+    LV2_OPTIONS__interface,
     "ui:idleInterface",
     "ui:showInterface",
+    "ui:resize",
 #if DISTRHO_PLUGIN_WANT_PROGRAMS
-    LV2_PROGRAMS__Interface,
+    LV2_PROGRAMS__UIInterface,
 #endif
     nullptr
 };

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -71,6 +71,121 @@
 #define DISTRHO_LV2_USE_EVENTS_OUT (DISTRHO_PLUGIN_WANT_MIDI_OUTPUT || (DISTRHO_PLUGIN_WANT_STATE && DISTRHO_PLUGIN_HAS_UI))
 
 // -----------------------------------------------------------------------
+static const char *const lv2ManifestPluginExtensionData[] =
+{
+    LV2_STATE__interface,
+#if DISTRHO_PLUGIN_WANT_STATE
+    LV2_OPTIONS__interface,
+    LV2_WORKER__interface,
+#endif
+#if DISTRHO_PLUGIN_WANT_PROGRAMS
+    LV2_PROGRAMS__Interface,
+#endif
+#ifdef DISTRHO_PLUGIN_LICENSED_FOR_MOD
+    MOD_LICENSE__interface,
+#endif
+    nullptr
+};
+
+static const char *const lv2ManifestPluginOptionalFeatures[] =
+{
+#if DISTRHO_PLUGIN_IS_RT_SAFE
+    LV2_CORE__hardRTCapable,
+#endif
+    LV2_BUF_SIZE__boundedBlockLength,
+    nullptr
+};
+
+static const char *const lv2ManifestPluginRequiredFeatures[] =
+{
+    LV2_OPTIONS__options,
+    LV2_URID__map,
+#if DISTRHO_PLUGIN_WANT_STATE
+    LV2_WORKER__schedule,
+#endif
+#ifdef DISTRHO_PLUGIN_LICENSED_FOR_MOD
+    MOD_LICENSE__feature,
+#endif
+    nullptr
+};
+
+static const char *const lv2ManifestPluginSupportedOptions[] =
+{
+    LV2_BUF_SIZE__nominalBlockLength,
+    LV2_BUF_SIZE__maxBlockLength,
+    LV2_PARAMETERS__sampleRate,
+    nullptr
+};
+
+#if DISTRHO_PLUGIN_HAS_UI
+static const char *const lv2ManifestUiExtensionData[] =
+{
+    "ui:idleInterface",
+    "ui:showInterface",
+#if DISTRHO_PLUGIN_WANT_PROGRAMS
+    LV2_PROGRAMS__Interface,
+#endif
+    nullptr
+};
+
+static const char *const lv2ManifestUiOptionalFeatures[] =
+{
+#if DISTRHO_PLUGIN_HAS_EMBED_UI
+# if !DISTRHO_UI_USER_RESIZABLE
+    "ui:noUserResize",
+# endif
+    "ui:resize",
+    "ui:touch",
+#endif
+    nullptr
+};
+
+static const char *const lv2ManifestUiRequiredFeatures[] =
+{
+#if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
+    LV2_DATA_ACCESS_URI,
+    LV2_INSTANCE_ACCESS_URI,
+#endif
+    LV2_OPTIONS__options,
+    LV2_URID__map,
+    nullptr
+};
+
+static const char *lv2ManifestUiSupportedOptions[] =
+{
+    LV2_PARAMETERS__sampleRate,
+    nullptr
+};
+#endif // DISTRHO_PLUGIN_HAS_UI
+
+static void addAttribute(String &text, unsigned indent, const char *attribute, const char* const values[])
+{
+    if (!values[0])
+        return;
+
+    size_t attributeLength = strlen(attribute);
+
+    for (unsigned i = 0; values[i]; ++i)
+    {
+        for (unsigned l = 0; l < indent; ++l)
+            text += " ";
+
+        if (i == 0)
+            text += attribute;
+        else
+            for (unsigned l = 0; l < attributeLength; ++l)
+                text += " ";
+        text += " ";
+
+        bool isUrl = strstr(values[i], "://") != nullptr;
+        if (isUrl) text += "<";
+        text += values[i];
+        if (isUrl) text += ">";
+        text += values[i + 1] ? " ,\n" : " ;\n\n";
+    }
+}
+
+// -----------------------------------------------------------------------
 
 DISTRHO_PLUGIN_EXPORT
 void lv2_generate_ttl(const char* const basename)
@@ -132,32 +247,11 @@ void lv2_generate_ttl(const char* const basename)
         manifestString += "    a ui:" DISTRHO_LV2_UI_TYPE " ;\n";
         manifestString += "    ui:binary <" + pluginUI + "." DISTRHO_DLL_EXTENSION "> ;\n";
 # if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
-        manifestString += "\n";
-        manifestString += "    lv2:extensionData ui:idleInterface ,\n";
-#  if DISTRHO_PLUGIN_WANT_PROGRAMS
-        manifestString += "                      ui:showInterface ,\n";
-        manifestString += "                      <" LV2_PROGRAMS__Interface "> ;\n";
-#  else
-        manifestString += "                      ui:showInterface ;\n";
-#  endif
-        manifestString += "\n";
-#  if DISTRHO_PLUGIN_HAS_EMBED_UI
-#   if DISTRHO_UI_USER_RESIZABLE
-        manifestString += "    lv2:optionalFeature ui:resize ,\n";
-        manifestString += "                        ui:touch ;\n";
-        manifestString += "\n";
-#   else // DISTRHO_UI_USER_RESIZABLE
-        manifestString += "    lv2:optionalFeature ui:noUserResize ,\n";
-        manifestString += "                        ui:resize ,\n";
-        manifestString += "                        ui:touch ;\n";
-        manifestString += "\n";
-#   endif // DISTRHO_UI_USER_RESIZABLE
-#  endif // DISTRHO_PLUGIN_HAS_EMBED_UI
-        manifestString += "    lv2:requiredFeature <" LV2_DATA_ACCESS_URI "> ,\n";
-        manifestString += "                        <" LV2_INSTANCE_ACCESS_URI "> ,\n";
-        manifestString += "                        <" LV2_OPTIONS__options "> ,\n";
-        manifestString += "                        <" LV2_URID__map "> ;\n";
-        manifestString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .\n";
+        addAttribute(manifestString, 4, "lv2:extensionData", lv2ManifestUiExtensionData);
+        addAttribute(manifestString, 4, "lv2:optionalFeature", lv2ManifestUiOptionalFeatures);
+        addAttribute(manifestString, 4, "lv2:requiredFeature", lv2ManifestUiRequiredFeatures);
+        addAttribute(manifestString, 4, "opts:supportedOption", lv2ManifestUiSupportedOptions);
+        manifestString[manifestString.rfind(';')] = '.';
 # else // DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
         manifestString += "    rdfs:seeAlso <" + uiTTL + "> .\n";
 # endif // DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
@@ -232,45 +326,10 @@ void lv2_generate_ttl(const char* const basename)
 #endif
         pluginString += "\n";
 
-        // extensionData
-        pluginString += "    lv2:extensionData <" LV2_STATE__interface "> ";
-#if DISTRHO_PLUGIN_WANT_STATE
-        pluginString += ",\n                      <" LV2_OPTIONS__interface "> ";
-        pluginString += ",\n                      <" LV2_WORKER__interface "> ";
-#endif
-#if DISTRHO_PLUGIN_WANT_PROGRAMS
-        pluginString += ",\n                      <" LV2_PROGRAMS__Interface "> ";
-#endif
-#ifdef DISTRHO_PLUGIN_LICENSED_FOR_MOD
-        pluginString += ",\n                      <" MOD_LICENSE__interface "> ";
-#endif
-        pluginString += ";\n\n";
-
-        // optionalFeatures
-#if DISTRHO_PLUGIN_IS_RT_SAFE
-        pluginString += "    lv2:optionalFeature <" LV2_CORE__hardRTCapable "> ,\n";
-        pluginString += "                        <" LV2_BUF_SIZE__boundedBlockLength "> ;\n";
-#else
-        pluginString += "    lv2:optionalFeature <" LV2_BUF_SIZE__boundedBlockLength "> ;\n";
-#endif
-        pluginString += "\n";
-
-        // requiredFeatures
-        pluginString += "    lv2:requiredFeature <" LV2_OPTIONS__options "> ";
-        pluginString += ",\n                        <" LV2_URID__map "> ";
-#if DISTRHO_PLUGIN_WANT_STATE
-        pluginString += ",\n                        <" LV2_WORKER__schedule "> ";
-#endif
-#ifdef DISTRHO_PLUGIN_LICENSED_FOR_MOD
-        pluginString += ",\n                        <" MOD_LICENSE__feature "> ";
-#endif
-        pluginString += ";\n\n";
-
-        // supportedOptions
-        pluginString += "    opts:supportedOption <" LV2_BUF_SIZE__nominalBlockLength "> ,\n";
-        pluginString += "                         <" LV2_BUF_SIZE__maxBlockLength "> ,\n";
-        pluginString += "                         <" LV2_PARAMETERS__sampleRate "> ;\n";
-        pluginString += "\n";
+        addAttribute(pluginString, 4, "lv2:extensionData", lv2ManifestPluginExtensionData);
+        addAttribute(pluginString, 4, "lv2:optionalFeature", lv2ManifestPluginOptionalFeatures);
+        addAttribute(pluginString, 4, "lv2:requiredFeature", lv2ManifestPluginRequiredFeatures);
+        addAttribute(pluginString, 4, "opts:supportedOption", lv2ManifestPluginSupportedOptions);
 
         // UI
 #if DISTRHO_PLUGIN_HAS_UI
@@ -635,30 +694,12 @@ void lv2_generate_ttl(const char* const basename)
         uiString += "\n";
 
         uiString += "<" DISTRHO_UI_URI ">\n";
-        uiString += "    lv2:extensionData ui:idleInterface ,\n";
-#  if DISTRHO_PLUGIN_WANT_PROGRAMS
-        uiString += "                      ui:showInterface ,\n";
-        uiString += "                      <" LV2_PROGRAMS__Interface "> ;\n";
-#  else
-        uiString += "                      ui:showInterface ;\n";
-#  endif
-        uiString += "\n";
-#  if DISTRHO_PLUGIN_HAS_EMBED_UI
-#   if DISTRHO_UI_USER_RESIZABLE
-        uiString += "    lv2:optionalFeature ui:resize ,\n";
-        uiString += "                        ui:touch ;\n";
-        uiString += "\n";
-#   else // DISTRHO_UI_USER_RESIZABLE
-        uiString += "    lv2:optionalFeature ui:noUserResize ,\n";
-        uiString += "                        ui:resize ,\n";
-        uiString += "                        ui:touch ;\n";
-        uiString += "\n";
-#   endif // DISTRHO_UI_USER_RESIZABLE
-#  endif // DISTRHO_PLUGIN_HAS_EMBED_UI
-        uiString += "    lv2:requiredFeature <" LV2_OPTIONS__options "> ,\n";
-        uiString += "                        <" LV2_URID__map "> ;\n";
 
-        uiString += "    opts:supportedOption <" LV2_PARAMETERS__sampleRate "> .\n";
+        addAttribute(uiString, 4, "lv2:extensionData", lv2ManifestUiExtensionData);
+        addAttribute(uiString, 4, "lv2:optionalFeature", lv2ManifestUiOptionalFeatures);
+        addAttribute(uiString, 4, "lv2:requiredFeature", lv2ManifestUiRequiredFeatures);
+        addAttribute(uiString, 4, "opts:supportedOption", lv2ManifestUiSupportedOptions);
+        uiString[uiString.rfind(';')] = '.';
 
         uiFile << uiString << std::endl;
         uiFile.close();

--- a/examples/CairoUI/CairoExamplePlugin.cpp
+++ b/examples/CairoUI/CairoExamplePlugin.cpp
@@ -40,7 +40,7 @@ public:
 
     const char* getLicense() const
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
     uint32_t getVersion() const

--- a/examples/CairoUI/DistrhoPluginInfo.h
+++ b/examples/CairoUI/DistrhoPluginInfo.h
@@ -19,7 +19,7 @@
    This is used to identify your plugin before a Plugin instance can be created.
    @note This macro is required.
  */
-#define DISTRHO_PLUGIN_NAME "Cairo DPF example"
+#define DISTRHO_PLUGIN_NAME "CairoUI"
 
 /**
    Number of audio inputs the plugin has.
@@ -37,7 +37,7 @@
    The plugin URI when exporting in LV2 format.
    @note This macro is required.
  */
-#define DISTRHO_PLUGIN_URI "urn:jpcima:cairo-dpf-example"
+#define DISTRHO_PLUGIN_URI "http://distrho.sf.net/examples/CairoUI"
 
 /**
    Wherever the plugin has a custom %UI.

--- a/examples/ExternalUI/ExternalExamplePlugin.cpp
+++ b/examples/ExternalUI/ExternalExamplePlugin.cpp
@@ -75,7 +75,7 @@ protected:
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/Info/InfoExamplePlugin.cpp
+++ b/examples/Info/InfoExamplePlugin.cpp
@@ -79,7 +79,7 @@ protected:
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/Latency/LatencyExamplePlugin.cpp
+++ b/examples/Latency/LatencyExamplePlugin.cpp
@@ -85,7 +85,7 @@ protected:
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/Meters/ExamplePluginMeters.cpp
+++ b/examples/Meters/ExamplePluginMeters.cpp
@@ -78,7 +78,7 @@ protected:
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/MidiThrough/MidiThroughExamplePlugin.cpp
+++ b/examples/MidiThrough/MidiThroughExamplePlugin.cpp
@@ -72,7 +72,7 @@ protected:
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/Parameters/ExamplePluginParameters.cpp
+++ b/examples/Parameters/ExamplePluginParameters.cpp
@@ -81,7 +81,7 @@ The plugin will be treated as an effect, but it will not change the host audio."
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**

--- a/examples/States/ExamplePluginStates.cpp
+++ b/examples/States/ExamplePluginStates.cpp
@@ -81,7 +81,7 @@ The plugin will be treated as an effect, but it will not change the host audio."
     */
     const char* getLicense() const override
     {
-        return "ISC";
+        return "http://opensource.org/licenses/isc";
     }
 
    /**


### PR DESCRIPTION
- Since the macro conditional logic began to get intricate, I have factored the code in the exporter such that there needn't be so much care taken regarding the syntax, and reduce error possibilities. ed1572a

It's a starting point so I can add and remove extension data easily, and I verified the examples manifests before/after using diff. Apart from some whitespace, it was identical.

- Licenses were changed to URI. 4cfa3d3
  At the same time, cairoUI's metadata was put in consistency with the rest of examples.

- Missing extension data were added. I checked it against LV2 wrappers source code.
  I found the KX program `Interface` to be mistaken for `UIInterface` and fixed it.

- Implemented the worker's response function. It's not supposed to be null.
  Implementation does nothing.