### PR TITLE
Add LV2 parameter comments

### DIFF
--- a/distrho/DistrhoPlugin.hpp
+++ b/distrho/DistrhoPlugin.hpp
@@ -407,6 +407,12 @@ struct Parameter {
     String unit;
 
    /**
+      An extensive comment/description about the parameter.
+      @note This value is optional.
+    */
+    String description;
+
+   /**
       Ranges of this parameter.@n
       The ranges describe the default, minimum and maximum values.
     */

--- a/distrho/src/DistrhoPluginInternal.hpp
+++ b/distrho/src/DistrhoPluginInternal.hpp
@@ -396,6 +396,13 @@ public:
         return fData->parameters[index].unit;
     }
 
+    const String& getParameterDescription(const uint32_t index) const noexcept
+    {
+        DISTRHO_SAFE_ASSERT_RETURN(fData != nullptr && index < fData->parameterCount, sFallbackString);
+
+        return fData->parameters[index].description;
+    }
+
     const ParameterEnumerationValues& getParameterEnumValues(const uint32_t index) const noexcept
     {
         DISTRHO_SAFE_ASSERT_RETURN(fData != nullptr && index < fData->parameterCount, sFallbackEnumValues);

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -613,6 +613,12 @@ void lv2_generate_ttl(const char* const basename)
                         }
                     }
 
+                    // comment
+                    const String& comment(plugin.getParameterDescription(i));
+
+                    if (comment.isNotEmpty())
+                        pluginString += "        rdfs:comment \"\"\"" + comment + "\"\"\" ;\n";
+
                     // hints
                     const uint32_t hints(plugin.getParameterHints(i));
 
@@ -645,7 +651,7 @@ void lv2_generate_ttl(const char* const basename)
             const String comment(plugin.getDescription());
 
             if (comment.isNotEmpty())
-                pluginString += "    rdfs:comment \"\"\"\n" + comment + "\n\"\"\" ;\n\n";
+                pluginString += "    rdfs:comment \"\"\"" + comment + "\"\"\" ;\n\n";
         }
 
 #ifdef DISTRHO_PLUGIN_BRAND


### PR DESCRIPTION
#164

Ability to set a description on LV2 parameters.

Also, there was a case of extra newlines in the plugin's comment.
I removed these newlines so the plugin text would go into the metadata unchanged.
