### PR TITLE
Fix an 'opts:interface not defined' warning

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -73,8 +73,8 @@
 // -----------------------------------------------------------------------
 static const char* const lv2ManifestPluginExtensionData[] =
 {
-#if DISTRHO_PLUGIN_WANT_STATE
     "opts:interface",
+#if DISTRHO_PLUGIN_WANT_STATE
     LV2_STATE__interface,
     LV2_WORKER__interface,
 #endif


### PR DESCRIPTION
Fix a remaining lv2 warning. Some change must have been lost in transit during the merging.
The plugin provides the options interface under all conditions; update extension data in order to reflect this.