### PR TITLE
[VST] Round integer param values after de-normalizing (fixes #171)

### DIFF
--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -925,14 +925,13 @@ public:
         const uint32_t hints(fPlugin.getParameterHints(index));
         const ParameterRanges& ranges(fPlugin.getParameterRanges(index));
 
+        value = ranges.getUnnormalizedValue(value);
+
         if (hints & kParameterIsBoolean)
         {
             const float midRange = ranges.min + (ranges.max - ranges.min) / 2.0f;
-
             value = value > midRange ? ranges.max : ranges.min;
         }
-
-        value = ranges.getUnnormalizedValue(value);
 
         if (hints & kParameterIsInteger)
         {

--- a/distrho/src/DistrhoPluginVST.cpp
+++ b/distrho/src/DistrhoPluginVST.cpp
@@ -575,7 +575,7 @@ public:
             else
             {
                 d_lastUiSampleRate = fPlugin.getSampleRate();
-                
+
                 // TODO
                 const float scaleFactor = 1.0f;
 
@@ -598,7 +598,7 @@ public:
                 }
 # endif
                 d_lastUiSampleRate = fPlugin.getSampleRate();
-                
+
                 // TODO
                 const float scaleFactor = 1.0f;
 
@@ -931,12 +931,15 @@ public:
 
             value = value > midRange ? ranges.max : ranges.min;
         }
-        else if (hints & kParameterIsInteger)
+
+        value = ranges.getUnnormalizedValue(value);
+
+        if (hints & kParameterIsInteger)
         {
             value = std::round(value);
         }
 
-        const float realValue(ranges.getUnnormalizedValue(value));
+        const float realValue(value);
         fPlugin.setParameterValue(index, realValue);
 
 #if DISTRHO_PLUGIN_HAS_UI
@@ -1306,7 +1309,7 @@ static intptr_t vst_dispatcherCallback(AEffect* effect, int32_t opcode, int32_t 
     case effGetParameterProperties:
         if (ptr != nullptr && index < static_cast<int32_t>(plugin.getParameterCount()))
         {
-            if (VstParameterProperties* const properties = (VstParameterProperties*)ptr) 
+            if (VstParameterProperties* const properties = (VstParameterProperties*)ptr)
             {
                 memset(properties, 0, sizeof(VstParameterProperties));
 


### PR DESCRIPTION
Has the additional (beneficial) effect, that params, which also have `kParameterIsBoolean` hint, are displayed as 0 and 1, not 0.0 and 1.0.