### PR TITLE
Suppress the copy methods of ParameterEnumerationValues (fixes #177)

### DIFF
--- a/distrho/DistrhoPlugin.hpp
+++ b/distrho/DistrhoPlugin.hpp
@@ -365,6 +365,8 @@ struct ParameterEnumerationValues {
             values = nullptr;
         }
     }
+
+    DISTRHO_DECLARE_NON_COPY_STRUCT(ParameterEnumerationValues)
 };
 
 /**

--- a/distrho/src/DistrhoDefines.h
+++ b/distrho/src/DistrhoDefines.h
@@ -128,7 +128,12 @@ private:                                           \
     StructName& operator=(StructName&) = delete;     \
     StructName& operator=(const StructName&) = delete;
 #else
-# define DISTRHO_DECLARE_NON_COPY_STRUCT(StructName)
+# define DISTRHO_DECLARE_NON_COPY_STRUCT(StructName) \
+private:                                             \
+    StructName(StructName&);                         \
+    StructName(const StructName&);                   \
+    StructName& operator=(StructName&);              \
+    StructName& operator=(const StructName&);
 #endif
 
 /* Define DISTRHO_PREVENT_HEAP_ALLOCATION */


### PR DESCRIPTION
Prevent copying the instances of `ParameterEnumerationValues`.