### PR TITLE
Allow generic units to pass validation

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -606,6 +606,7 @@ void lv2_generate_ttl(const char* const basename)
                         else
                         {
                             pluginString += "        unit:unit [\n";
+                            pluginString += "            a unit:Unit ;\n";
                             pluginString += "            rdfs:label  \"" + unit + "\" ;\n";
                             pluginString += "            unit:symbol \"" + unit + "\" ;\n";
                             pluginString += "            unit:render \"%f " + unit + "\" ;\n";


### PR DESCRIPTION
It would fail with this error below.
```
    [FAIL]  Units
              units_unit not a URI or object
              seeAlso: <http://lv2plug.in/ns/extensions/units#unit>
```