### PR TITLE
Fix the build in case the DISTRHO namespace is not used

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -160,7 +160,7 @@ static const char* const lv2ManifestUiSupportedOptions[] =
 };
 #endif // DISTRHO_PLUGIN_HAS_UI
 
-static void addAttribute(String& text,
+static void addAttribute(DISTRHO::String& text,
                          const char* const attribute,
                          const char* const values[],
                          const uint indent,


### PR DESCRIPTION
The build was broken in case the plugin is compiled with `-DDONT_SET_USING_DISTRHO_NAMESPACE`.
