### PR TITLE
Fix setting the bypass parameter at init

### DIFF
--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -166,6 +166,48 @@ public:
 
     // -------------------------------------------------------------------
 
+    bool getPortControlValue(uint32_t index, float *value) const
+    {
+        const float* control = fPortControls[index];
+
+        if (control == nullptr)
+            return false;
+
+        switch (fPlugin.getParameterDesignation(index))
+        {
+        default:
+            *value = *control;
+            break;
+        case kParameterDesignationBypass:
+            *value = 1.0f - *control;
+            break;
+        }
+
+        return true;
+    }
+
+    bool setPortControlValue(uint32_t index, float value)
+    {
+        float* control = fPortControls[index];
+
+        if (control == nullptr)
+            return false;
+
+        switch (fPlugin.getParameterDesignation(index))
+        {
+        default:
+            *control = value;
+            break;
+        case kParameterDesignationBypass:
+            *control = 1.0f - value;
+            break;
+        }
+
+        return true;
+    }
+
+    // -------------------------------------------------------------------
+
     void lv2_activate()
     {
 #if DISTRHO_PLUGIN_WANT_TIMEPOS
@@ -514,17 +556,12 @@ public:
 
         for (uint32_t i=0, count=fPlugin.getParameterCount(); i < count; ++i)
         {
-            if (fPortControls[i] == nullptr)
+            if (!getPortControlValue(i, &curValue))
                 continue;
-
-            curValue = *fPortControls[i];
 
             if (fPlugin.isParameterInput(i) && d_isNotEqual(fLastControlValues[i], curValue))
             {
                 fLastControlValues[i] = curValue;
-
-                if (fPlugin.getParameterDesignation(i) == kParameterDesignationBypass)
-                    curValue = 1.0f - curValue;
 
                 fPlugin.setParameterValue(i, curValue);
             }
@@ -757,8 +794,7 @@ public:
 
             fLastControlValues[i] = fPlugin.getParameterValue(i);
 
-            if (fPortControls[i] != nullptr)
-                *fPortControls[i] = fLastControlValues[i];
+            setPortControlValue(i, fLastControlValues[i]);
         }
 
 # if DISTRHO_PLUGIN_WANT_FULL_STATE
@@ -1047,8 +1083,7 @@ private:
             {
                 curValue = fLastControlValues[i] = fPlugin.getParameterValue(i);
 
-                if (fPortControls[i] != nullptr)
-                    *fPortControls[i] = curValue;
+                setPortControlValue(i, curValue);
             }
             else if ((fPlugin.getParameterHints(i) & kParameterIsTrigger) == kParameterIsTrigger)
             {

--- a/distrho/src/DistrhoPluginLV2.cpp
+++ b/distrho/src/DistrhoPluginLV2.cpp
@@ -166,44 +166,40 @@ public:
 
     // -------------------------------------------------------------------
 
-    bool getPortControlValue(uint32_t index, float *value) const
+    bool getPortControlValue(uint32_t index, float& value) const
     {
-        const float* control = fPortControls[index];
-
-        if (control == nullptr)
-            return false;
-
-        switch (fPlugin.getParameterDesignation(index))
+        if (const float* control = fPortControls[index])
         {
-        default:
-            *value = *control;
-            break;
-        case kParameterDesignationBypass:
-            *value = 1.0f - *control;
-            break;
+            switch (fPlugin.getParameterDesignation(index))
+            {
+            default:
+                value = *control;
+                break;
+            case kParameterDesignationBypass:
+                value = 1.0f - *control;
+                break;
+            }
+
+            return true;
         }
 
-        return true;
+        return false;
     }
 
-    bool setPortControlValue(uint32_t index, float value)
+    void setPortControlValue(uint32_t index, float value)
     {
-        float* control = fPortControls[index];
-
-        if (control == nullptr)
-            return false;
-
-        switch (fPlugin.getParameterDesignation(index))
+        if (float* control = fPortControls[index])
         {
-        default:
-            *control = value;
-            break;
-        case kParameterDesignationBypass:
-            *control = 1.0f - value;
-            break;
+            switch (fPlugin.getParameterDesignation(index))
+            {
+            default:
+                *control = value;
+                break;
+            case kParameterDesignationBypass:
+                *control = 1.0f - value;
+                break;
+            }
         }
-
-        return true;
     }
 
     // -------------------------------------------------------------------
@@ -556,7 +552,7 @@ public:
 
         for (uint32_t i=0, count=fPlugin.getParameterCount(); i < count; ++i)
         {
-            if (!getPortControlValue(i, &curValue))
+            if (!getPortControlValue(i, curValue))
                 continue;
 
             if (fPlugin.isParameterInput(i) && d_isNotEqual(fLastControlValues[i], curValue))


### PR DESCRIPTION
There is a problem reloading a saved LV2 plugin state having enabled=off (aka bypass=on).

The comparison of Port value vs. Last parameter value is producing `0 != 0` initially, and plugin does not receive setParameterValue for the bypass. It happens in Ardour.

It's not the UI problem reported before, this is yet something else.

For detail see: https://github.com/jpcima/stone-phaser/issues/2
Also: https://forum.moddevices.com/t/stone-phaser-a-vintage-analog-phaser-pedal/

If the proposition is fine as a solution, this would add a pair of methods which invert as needed, when exchanging value between parameter and port, in either direction.