### PR TITLE
Fix swapped minor/micro version number when exporting LV2 TTL

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -691,15 +691,15 @@ void lv2_generate_ttl(const char* const basename)
             const uint32_t version(plugin.getVersion());
 
             const uint32_t majorVersion = (version & 0xFF0000) >> 16;
-            const uint32_t microVersion = (version & 0x00FF00) >> 8;
-            /* */ uint32_t minorVersion = (version & 0x0000FF) >> 0;
+            /* */ uint32_t minorVersion = (version & 0x00FF00) >> 8;
+            const uint32_t microVersion = (version & 0x0000FF) >> 0;
 
             // NOTE: LV2 ignores 'major' version and says 0 for minor is pre-release/unstable.
             if (majorVersion > 0)
                 minorVersion += 2;
 
-            pluginString += "    lv2:microVersion " + String(microVersion) + " ;\n";
-            pluginString += "    lv2:minorVersion " + String(minorVersion) + " .\n";
+            pluginString += "    lv2:minorVersion " + String(minorVersion) + " ;\n";
+            pluginString += "    lv2:microVersion " + String(microVersion) + " .\n";
         }
 
         pluginFile << pluginString << std::endl;


### PR DESCRIPTION
Reference: http://lv2plug.in/ns/lv2core/lv2core.html#minorVersion

See also `d_version` in [DistrhoUtils.hpp](distrho/DistrhoUtils.hpp#69).