### PR TITLE
Support disabling window decorations in X11 and Win32

### DIFF
--- a/dgl/Window.hpp
+++ b/dgl/Window.hpp
@@ -100,6 +100,9 @@ public:
     bool isResizable() const noexcept;
     void setResizable(bool yesNo);
 
+    bool isDecorated() const noexcept;
+    void setDecorated(bool yesNo);
+
     uint getWidth() const noexcept;
     uint getHeight() const noexcept;
     Size<uint> getSize() const noexcept;


### PR DESCRIPTION
Hi, this adds ability to hide the window captions.
It's a starting point to implement such things as popup menu widgets.

- On X11, it's using some Motif properties, which seems the widespread method from various toolkits.

- On Windows, it's the style `WS_CAPTION`, needing some particular care to set it on/off.
It needs to recalculate the adjusted window size after setting the hint. I will preserve the former position of the window.

A detail: the window's drawable area has an offset between caption on/off on Windows, because the title bar's top-left is considered the rectangle's origin, unlike in X11.

Other: on Windows it still has the resize border, unless setting `isResizable` to false.

macOS to be implemented..