### PR TITLE
Fix user-resizable embedded window in Reaper Mac

### DIFF
--- a/dgl/src/pugl/pugl_osx.m
+++ b/dgl/src/pugl/pugl_osx.m
@@ -329,6 +329,7 @@ flagsChanged(NSView<PuglGenericView> *self, NSEvent *event)
 - (void) keyDown:(NSEvent*)event;
 - (void) keyUp:(NSEvent*)event;
 - (void) flagsChanged:(NSEvent*)event;
+- (void) resizeWithOldSuperviewSize:(NSSize)oldSize;
 
 @end
 
@@ -527,6 +528,21 @@ flagsChanged(NSView<PuglGenericView> *self, NSEvent *event)
 	flagsChanged(self, event);
 }
 
+- (void) resizeWithOldSuperviewSize:(NSSize)oldSize
+{
+	PuglView *pv = self->puglview;
+
+	if (pv->width <= 1 && pv->height <= 1)
+	{
+		/* NOTE: if the view size was not initialized yet, don't perform an
+		   autoresize; it fixes manual resizing in Reaper.
+		 */
+		return;
+	}
+
+	[super resizeWithOldSuperviewSize:oldSize];
+}
+
 @end
 #endif
 
@@ -570,6 +586,7 @@ flagsChanged(NSView<PuglGenericView> *self, NSEvent *event)
 - (void) keyDown:(NSEvent*)event;
 - (void) keyUp:(NSEvent*)event;
 - (void) flagsChanged:(NSEvent*)event;
+- (void) resizeWithOldSuperviewSize:(NSSize)oldSize;
 @end
 
 @implementation PuglCairoView
@@ -749,6 +766,22 @@ flagsChanged(NSView<PuglGenericView> *self, NSEvent *event)
 {
 	flagsChanged(self, event);
 }
+
+- (void) resizeWithOldSuperviewSize:(NSSize)oldSize
+{
+	PuglView *pv = self->puglview;
+
+	if (pv->width <= 1 && pv->height <= 1)
+	{
+		/* NOTE: if the view size was not initialized yet, don't perform an
+		   autoresize; it fixes manual resizing in Reaper.
+		 */
+		return;
+	}
+
+	[super resizeWithOldSuperviewSize:oldSize];
+}
+
 @end
 #endif
 


### PR DESCRIPTION
This will inhibit applying the auto-resize mask until
the initial size has been set in the PuglView. Initially,
DPF would set this size to (1, 1).

It's a very simple solution for #198, too simple maybe.
It needs to verify if it hasn't broken something else.