### PR TITLE
lv2: require the idleInterface feature

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -145,6 +145,7 @@ static const char* const lv2ManifestUiOptionalFeatures[] =
 static const char* const lv2ManifestUiRequiredFeatures[] =
 {
     "opts:options",
+    "ui:idleInterface",
 #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
     LV2_DATA_ACCESS_URI,
     LV2_INSTANCE_ACCESS_URI,


### PR DESCRIPTION
lv2lint 0.2.0 complains about the `idleInterface` feature when it's not requested.
This problem has been reported in Ninjas2: https://github.com/rghvdberg/ninjas2/issues/76

```
    [FAIL]  Idle Interface
              lv2:feature ui:idleInterface missing
              seeAlso: <http://lv2plug.in/ns/extensions/ui#idleInterface>
```