### PR TITLE
Link all plugins to math lib because math functions are used in DGL

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -98,7 +98,7 @@ DGL_FLAGS += -DDGL_EXTERNAL
 HAVE_DGL   = true
 endif
 
-DGL_LIBS += $(DGL_SYSTEM_LIBS)
+DGL_LIBS += $(DGL_SYSTEM_LIBS) -lm
 
 ifneq ($(HAVE_DGL),true)
 dssi_ui =


### PR DESCRIPTION
This should resolve any backward compatibility issues with glibc by versioning all math symbols.