### PR TITLE
Allow building projects outside the examples dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: dgl examples gen
 
 ifneq ($(CROSS_COMPILING),true)
 CAN_GENERATE_TTL = true
-else ifeq ($(EXE_WRAPPER),)
+else ifneq ($(EXE_WRAPPER),)
 CAN_GENERATE_TTL = true
 endif
 
@@ -41,7 +41,7 @@ ifneq ($(MACOS_OR_WINDOWS),true)
 	install -m 755 examples/ExternalUI/ExternalLauncher.sh bin/d_extui.lv2/d_extui.sh
 endif
 
-ifneq ($(CAN_GENERATE_TTL),true)
+ifeq ($(CAN_GENERATE_TTL),true)
 gen: examples utils/lv2_ttl_generator
 	@$(CURDIR)/utils/generate-ttl.sh
 ifeq ($(MACOS),true)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ all: dgl examples gen
 
 # --------------------------------------------------------------
 
+ifneq ($(CROSS_COMPILING),true)
+CAN_GENERATE_TTL = true
+else ifeq ($(EXE_WRAPPER),)
+CAN_GENERATE_TTL = true
+endif
+
 dgl:
 	$(MAKE) -C dgl
 
@@ -35,7 +41,7 @@ ifneq ($(MACOS_OR_WINDOWS),true)
 	install -m 755 examples/ExternalUI/ExternalLauncher.sh bin/d_extui.lv2/d_extui.sh
 endif
 
-ifneq ($(CROSS_COMPILING),true)
+ifneq ($(CAN_GENERATE_TTL),true)
 gen: examples utils/lv2_ttl_generator
 	@$(CURDIR)/utils/generate-ttl.sh
 ifeq ($(MACOS),true)

--- a/Makefile.base.mk
+++ b/Makefile.base.mk
@@ -63,6 +63,10 @@ ifneq (,$(filter arm%,$(TARGET_PROCESSOR)))
 CPU_ARM=true
 CPU_ARM_OR_AARCH64=true
 endif
+ifneq (,$(filter arm64%,$(TARGET_PROCESSOR)))
+CPU_ARM64=true
+CPU_ARM_OR_AARCH64=true
+endif
 ifneq (,$(filter aarch64%,$(TARGET_PROCESSOR)))
 CPU_AARCH64=true
 CPU_ARM_OR_AARCH64=true
@@ -132,11 +136,13 @@ BASE_FLAGS = -Wall -Wextra -pipe -MD -MP
 BASE_OPTS  = -O3 -ffast-math -fdata-sections -ffunction-sections
 
 ifeq ($(CPU_I386_OR_X86_64),true)
-BASE_OPTS += -mtune=generic -msse -msse2
+BASE_OPTS += -mtune=generic -msse -msse2 -mfpmath=sse
 endif
 
 ifeq ($(CPU_ARM),true)
+ifneq ($(CPU_ARM64),true)
 BASE_OPTS += -mfpu=neon-vfpv4 -mfloat-abi=hard
+endif
 endif
 
 ifeq ($(MACOS),true)
@@ -285,6 +291,7 @@ OPENGL_LIBS  = $(shell $(PKG_CONFIG) --libs gl)
 endif
 
 ifeq ($(MACOS),true)
+OPENGL_FLAGS = -DGL_SILENCE_DEPRECATION=1
 OPENGL_LIBS  = -framework OpenGL
 endif
 

--- a/Makefile.base.mk
+++ b/Makefile.base.mk
@@ -239,6 +239,9 @@ HAVE_LIBLO = $(shell $(PKG_CONFIG) --exists liblo && echo true)
 # ---------------------------------------------------------------------------------------------------------------------
 # Set Generic DGL stuff
 
+# needed because reasons (specifically, libc broke ABI)
+DGL_FLAGS = -fno-finite-math-only
+
 ifeq ($(HAIKU),true)
 DGL_SYSTEM_LIBS += -lbe
 endif

--- a/Makefile.base.mk
+++ b/Makefile.base.mk
@@ -239,9 +239,6 @@ HAVE_LIBLO = $(shell $(PKG_CONFIG) --exists liblo && echo true)
 # ---------------------------------------------------------------------------------------------------------------------
 # Set Generic DGL stuff
 
-# needed because reasons (specifically, libc broke ABI)
-DGL_FLAGS = -fno-finite-math-only
-
 ifeq ($(HAIKU),true)
 DGL_SYSTEM_LIBS += -lbe
 endif

--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -98,7 +98,7 @@ DGL_FLAGS += -DDGL_EXTERNAL
 HAVE_DGL   = true
 endif
 
-DGL_LIBS += $(DGL_SYSTEM_LIBS)
+DGL_LIBS += $(DGL_SYSTEM_LIBS) -lm
 
 ifneq ($(HAVE_DGL),true)
 dssi_ui =

--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -7,10 +7,14 @@
 # NOTE: NAME, FILES_DSP and FILES_UI must have been defined before including this file!
 
 
+ifeq ($(DPF_CUSTOM_PATH),)
 ifeq (,$(wildcard ../../Makefile.base.mk))
 DPF_PATH=../../dpf
 else
 DPF_PATH=../..
+endif
+else
+DPF_PATH = $(DPF_CUSTOM_PATH)
 endif
 
 include $(DPF_PATH)/Makefile.base.mk
@@ -18,8 +22,21 @@ include $(DPF_PATH)/Makefile.base.mk
 # ---------------------------------------------------------------------------------------------------------------------
 # Basic setup
 
+ifeq ($(DPF_CUSTOM_PATH),)
 TARGET_DIR = ../../bin
 BUILD_DIR = ../../build/$(NAME)
+else
+ifeq ($(DPF_CUSTOM_TARGET_DIR),)
+$(error DPF_CUSTOM_TARGET_DIR is not set)
+else
+TARGET_DIR = $(DPF_CUSTOM_TARGET_DIR)
+endif
+ifeq ($(DPF_CUSTOM_BUILD_DIR),)
+$(error DPF_CUSTOM_BUILD_DIR is not set)
+else
+BUILD_DIR = $(DPF_CUSTOM_BUILD_DIR)
+endif
+endif
 
 BUILD_C_FLAGS   += -I.
 BUILD_CXX_FLAGS += -I. -I$(DPF_PATH)/distrho -I$(DPF_PATH)/dgl

--- a/dgl/src/ImageWidgets.cpp
+++ b/dgl/src/ImageWidgets.cpp
@@ -612,8 +612,9 @@ bool ImageKnob::onScroll(const ScrollEvent& ev)
     if (! contains(ev.pos))
         return false;
 
+    const float dir   = (ev.delta.getY() > 0.f) ? 1.f : -1.f;
     const float d     = (ev.mod & kModifierControl) ? 2000.0f : 200.0f;
-    float       value = (fUsingLog ? _invlogscale(fValueTmp) : fValueTmp) + (float(fMaximum - fMinimum) / d * 10.f * ev.delta.getY());
+    float       value = (fUsingLog ? _invlogscale(fValueTmp) : fValueTmp) + (float(fMaximum - fMinimum) / d * 10.f * dir);
 
     if (fUsingLog)
         value = _logscale(value);

--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -28,6 +28,6 @@ FOLDERS=`find . -type d -name \*.lv2`
 for i in ${FOLDERS}; do
   cd ${i}
   FILE="$(ls *.${EXT} | sort | head -n 1)"
-  "${EXE_WRAPPER}" "${GEN}" "./${FILE}"
+  ${EXE_WRAPPER} "${GEN}" "./${FILE}"
   cd ..
 done

--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -9,13 +9,13 @@ else
   exit
 fi
 
-PWD="$(dirname "$0")"
+PWD="$(dirname "${0}")"
 
-if [ -f "$PWD/lv2_ttl_generator.exe" ]; then
-  GEN="$PWD/lv2_ttl_generator.exe"
+if [ -f "${PWD}/lv2_ttl_generator.exe" ]; then
+  GEN="${PWD}/lv2_ttl_generator.exe"
   EXT=dll
 else
-  GEN="$PWD/lv2_ttl_generator"
+  GEN="${PWD}/lv2_ttl_generator"
   if [ -d /Library/Audio ]; then
     EXT=dylib
   else
@@ -25,9 +25,9 @@ fi
 
 FOLDERS=`find . -type d -name \*.lv2`
 
-for i in $FOLDERS; do
-  cd $i
-  FILE="$(ls *.$EXT | sort | head -n 1)"
-  "$GEN" "./$FILE"
+for i in ${FOLDERS}; do
+  cd ${i}
+  FILE="$(ls *.${EXT} | sort | head -n 1)"
+  "${EXE_WRAPPER}" "${GEN}" "./${FILE}"
   cd ..
 done


### PR DESCRIPTION
This patch allows setting a `DPF_CUSTOM_PATH` in a DPF project Makefile to allow building projects located outside the Examples directory.

/random/path/Makefile:

```
# Makefile for DISTRHO Plugins #
# ---------------------------- #
# Created by falkTX

DPF_CUSTOM_PATH = /usr/local/src/DPF
DPF_CUSTOM_TARGET_DIR = bin
DPF_CUSTOM_BUILD_DIR = build

...
```

I did it out of necessity for a new project I am working on https://github.com/lucianoiam/dpf-webview

Not sure this is the best way to setup a DPF project but it gave me good results so far.
