### PR TITLE
Allow building projects outside the examples dir

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -7,10 +7,14 @@
 # NOTE: NAME, FILES_DSP and FILES_UI must have been defined before including this file!
 
 
+ifeq ($(DPF_CUSTOM_PATH),)
 ifeq (,$(wildcard ../../Makefile.base.mk))
 DPF_PATH=../../dpf
 else
 DPF_PATH=../..
+endif
+else
+DPF_PATH = $(DPF_CUSTOM_PATH)
 endif
 
 include $(DPF_PATH)/Makefile.base.mk
@@ -18,8 +22,21 @@ include $(DPF_PATH)/Makefile.base.mk
 # ---------------------------------------------------------------------------------------------------------------------
 # Basic setup
 
+ifeq ($(DPF_CUSTOM_PATH),)
 TARGET_DIR = ../../bin
 BUILD_DIR = ../../build/$(NAME)
+else
+ifeq ($(DPF_CUSTOM_TARGET_DIR),)
+$(error DPF_CUSTOM_TARGET_DIR is not set)
+else
+TARGET_DIR = $(DPF_CUSTOM_TARGET_DIR)
+endif
+ifeq ($(DPF_CUSTOM_BUILD_DIR),)
+$(error DPF_CUSTOM_BUILD_DIR is not set)
+else
+BUILD_DIR = $(DPF_CUSTOM_BUILD_DIR)
+endif
+endif
 
 BUILD_C_FLAGS   += -I.
 BUILD_CXX_FLAGS += -I. -I$(DPF_PATH)/distrho -I$(DPF_PATH)/dgl


### PR DESCRIPTION
Supersedes https://github.com/DISTRHO/DPF/pull/249 to target branch develop

Project Makefiles can now define a DPF_CUSTOM_PATH

When setting a DPF_CUSTOM_PATH also DPF_CUSTOM_TARGET_DIR (for binaries) and
DPF_CUSTOM_BUILD_DIR (objects) need to be set.

If the project depends on DPF's graphic library, it has to be built first by
cd'ing to DPF and running make dgl
