### PR TITLE
Fixes #258

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -565,10 +565,7 @@ void lv2_generate_ttl(const char* const basename)
                             pluginString += "            rdfs:label  \"\"\"" + enumValue.label + "\"\"\" ;\n";
 
                             if (plugin.getParameterHints(i) & kParameterIsInteger) {
-								if(enumValue.value < 0.0)
-                                    pluginString += "            rdf:value " + String((int)(enumValue.value - 0.5f)) + " ;\n";
-                                else
-                                    pluginString += "            rdf:value " + String((int)(enumValue.value + 0.5f)) + " ;\n";
+                                pluginString += "            rdf:value " + String((int)(enumValue.value + ((enumValue.value < 0.0)?-0.5f:0.5f))) + " ;\n";
                             }
                             else {
                                 pluginString += "            rdf:value " + String(enumValue.value) + " ;\n";

--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -565,8 +565,10 @@ void lv2_generate_ttl(const char* const basename)
                             pluginString += "            rdfs:label  \"\"\"" + enumValue.label + "\"\"\" ;\n";
 
                             if (plugin.getParameterHints(i) & kParameterIsInteger) {
-                                const int roundedValue = (int)(enumValue.value + 0.5f);
-                                pluginString += "            rdf:value " + String(roundedValue) + " ;\n";
+								if(enumValue.value < 0.0)
+                                    pluginString += "            rdf:value " + String((int)(enumValue.value - 0.5f)) + " ;\n";
+                                else
+                                    pluginString += "            rdf:value " + String((int)(enumValue.value + 0.5f)) + " ;\n";
                             }
                             else {
                                 pluginString += "            rdf:value " + String(enumValue.value) + " ;\n";


### PR DESCRIPTION
Fixes #258 - wrong value detected for negative enums of integer parameters

Simple fixe to check which directon to round integers. Up if positive and down if negative. Although this may not be the optimal mechanism it is only used when creating configuration files, not during runtime.