### PR TITLE
Fix build with DGL_FILE_BROWSER_DISABLED

### DIFF
--- a/dgl/src/WindowPrivateData.cpp
+++ b/dgl/src/WindowPrivateData.cpp
@@ -426,6 +426,7 @@ bool Window::PrivateData::removeIdleCallback(IdleCallback* const callback)
     return puglStopTimer(view, (uintptr_t)callback) == PUGL_SUCCESS;
 }
 
+#ifndef DGL_FILE_BROWSER_DISABLED
 // -----------------------------------------------------------------------
 // file handling
 
@@ -536,6 +537,7 @@ bool Window::PrivateData::openFileBrowser(const Window::FileBrowserOptions& opti
 
     return false;
 }
+#endif
 
 // -----------------------------------------------------------------------
 // modal handling

--- a/dgl/src/WindowPrivateData.hpp
+++ b/dgl/src/WindowPrivateData.hpp
@@ -143,8 +143,10 @@ struct Window::PrivateData : IdleCallback {
     bool addIdleCallback(IdleCallback* callback, uint timerFrequencyInMs);
     bool removeIdleCallback(IdleCallback* callback);
 
+#ifndef DGL_FILE_BROWSER_DISABLED
     // file handling
     bool openFileBrowser(const Window::FileBrowserOptions& options);
+#endif
 
     // modal handling
     void startModal();


### PR DESCRIPTION
On the develop branch, the build would fail with the following error when DGL_FILE_BROWSER_DISABLED is set:

```
src/WindowPrivateData.hpp:147:40: error: ‘FileBrowserOptions’ in ‘class WolfShaperDGL::Window’ does not name a type
```