### PR TITLE
cmake: generate the macOS namespace for pugl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build_for_linux:
+  cmake_linux:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -40,9 +40,45 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake "$GITHUB_WORKSPACE" -G Ninja \
-          -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-          -DDPF_EXAMPLES=ON
+          -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
     - name: Build all
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config "$BUILD_TYPE" -j 2
+    - name: Display built files
+      shell: bash
+      working-directory: ${{runner.workspace}}/build/bin
+      run: ls -lFR
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Linux artifacts
+        path: ${{runner.workspace}}/build/bin/
+
+  cmake_macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Create Build Environment
+      shell: bash
+      working-directory: ${{runner.workspace}}
+      run: cmake -E make_directory build
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        cmake "$GITHUB_WORKSPACE" \
+          -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    - name: Build all
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config "$BUILD_TYPE" -j 2
+    - name: Display built files
+      shell: bash
+      working-directory: ${{runner.workspace}}/build/bin
+      run: ls -lFR
+    - uses: actions/upload-artifact@v2
+      with:
+        name: macOS artifacts
+        path: ${{runner.workspace}}/build/bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ cmake_minimum_required(VERSION 3.7)
 
 project(DPF)
 
+# ensure c++11 at minimum, the parent project can override
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
 # check if we are building from this project, or are imported by another
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(DPF_BUILD_FROM_HERE TRUE)
@@ -24,12 +29,16 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(DPF-plugin)
 
 if(DPF_LIBRARIES)
-  dpf__add_dgl_cairo()
+  if(NOT (MSVC OR APPLE)) # TODO skip this one for now
+    dpf__add_dgl_cairo()
+  endif()
   dpf__add_dgl_opengl()
 endif()
 
 if(DPF_EXAMPLES)
-  add_subdirectory("examples/CairoUI")
+  if(NOT (MSVC OR APPLE)) # TODO skip this one for now
+    add_subdirectory("examples/CairoUI")
+  endif()
   #add_subdirectory("examples/ExternalUI")
   add_subdirectory("examples/FileHandling")
   add_subdirectory("examples/Info")


### PR DESCRIPTION
This implements the pugl namespace in the macOS build with cmake.
In addition:
- for now, disable cairo stuff on macOS (and MSVC)
- add the CI workflow for macOS and CMake
- make build artifacts available, to validate that macOS namespacing works (it does)
- add required changes for macOS to build