### PR TITLE
Build with MS compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,79 @@ jobs:
       with:
         name: macOS artifacts
         path: ${{runner.workspace}}/build/bin/
+
+  cmake_win32:
+    runs-on: windows-2019
+    steps:
+    - name: Set environment
+      run: |
+        echo "release_arch=Win32" >> "${Env:GITHUB_ENV}"
+        echo "vcpkg_triplet=x86-windows-static" >> "${Env:GITHUB_ENV}"
+        echo "vcpkg_git_commit_id=a3db16a4475b963cacf0260068c497fb72c8f3c0" >> "${Env:GITHUB_ENV}"
+    - name: Restore from cache and install vcpkg
+      uses: lukka/run-vcpkg@v6
+      with:
+        setupOnly: true
+        vcpkgTriplet: ${{env.vcpkg_triplet}}
+        vcpkgGitCommitId: ${{env.vcpkg_git_commit_id}}
+    #- name: Install packages
+    #  run: |
+    #    & "${Env:VCPKG_ROOT}/vcpkg" install "cairo:${Env:vcpkg_triplet}"
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Create Build Environment
+      working-directory: ${{runner.workspace}}
+      run: cmake -E make_directory build
+    - name: Configure CMake
+      working-directory: ${{runner.workspace}}/build
+      run: |
+       cmake "${Env:GITHUB_WORKSPACE}" -G"Visual Studio 16 2019" -A"${Env:release_arch}" -DCMAKE_BUILD_TYPE="${Env:BUILD_TYPE}" -DVCPKG_TARGET_TRIPLET="${Env:vcpkg_triplet}" -DCMAKE_TOOLCHAIN_FILE="${Env:VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    - name: Build all
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config "${Env:BUILD_TYPE}" -j 2
+    - name: Show built files
+      working-directory: ${{runner.workspace}}/build/bin
+      run: tree
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Win32 artifacts
+        path: ${{runner.workspace}}/build/bin/
+
+  cmake_win64:
+    runs-on: windows-2019
+    steps:
+    - name: Set environment
+      run: |
+        echo "release_arch=x64" >> "${Env:GITHUB_ENV}"
+        echo "vcpkg_triplet=x64-windows-static" >> "${Env:GITHUB_ENV}"
+        echo "vcpkg_git_commit_id=a3db16a4475b963cacf0260068c497fb72c8f3c0" >> "${Env:GITHUB_ENV}"
+    - name: Restore from cache and install vcpkg
+      uses: lukka/run-vcpkg@v6
+      with:
+        setupOnly: true
+        vcpkgTriplet: ${{env.vcpkg_triplet}}
+        vcpkgGitCommitId: ${{env.vcpkg_git_commit_id}}
+    #- name: Install packages
+    #  run: |
+    #    & "${Env:VCPKG_ROOT}/vcpkg" install "cairo:${Env:vcpkg_triplet}"
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Create Build Environment
+      working-directory: ${{runner.workspace}}
+      run: cmake -E make_directory build
+    - name: Configure CMake
+      working-directory: ${{runner.workspace}}/build
+      run: |
+       cmake "${Env:GITHUB_WORKSPACE}" -G"Visual Studio 16 2019" -A"${Env:release_arch}" -DCMAKE_BUILD_TYPE="${Env:BUILD_TYPE}" -DVCPKG_TARGET_TRIPLET="${Env:vcpkg_triplet}" -DCMAKE_TOOLCHAIN_FILE="${Env:VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    - name: Build all
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config "${Env:BUILD_TYPE}" -j 2
+    - name: Show built files
+      working-directory: ${{runner.workspace}}/build/bin
+      run: tree
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Win64 artifacts
+        path: ${{runner.workspace}}/build/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 .kdev_include_paths
 .kdev4/
 .DS_Store
+.vs/
+CMakeSettings.json
 
 bin/
 build/

--- a/distrho/DistrhoUtils.hpp
+++ b/distrho/DistrhoUtils.hpp
@@ -94,12 +94,12 @@ static inline
 void d_debug(const char* const fmt, ...) noexcept
 {
     try {
-        ::va_list args;
-        ::va_start(args, fmt);
+        va_list args;
+        va_start(args, fmt);
         std::fprintf(stdout, "\x1b[30;1m");
         std::vfprintf(stdout, fmt, args);
         std::fprintf(stdout, "\x1b[0m\n");
-        ::va_end(args);
+        va_end(args);
     } catch (...) {}
 }
 #endif
@@ -111,11 +111,11 @@ static inline
 void d_stdout(const char* const fmt, ...) noexcept
 {
     try {
-        ::va_list args;
-        ::va_start(args, fmt);
+        va_list args;
+        va_start(args, fmt);
         std::vfprintf(stdout, fmt, args);
         std::fprintf(stdout, "\n");
-        ::va_end(args);
+        va_end(args);
     } catch (...) {}
 }
 
@@ -126,11 +126,11 @@ static inline
 void d_stderr(const char* const fmt, ...) noexcept
 {
     try {
-        ::va_list args;
-        ::va_start(args, fmt);
+        va_list args;
+        va_start(args, fmt);
         std::vfprintf(stderr, fmt, args);
         std::fprintf(stderr, "\n");
-        ::va_end(args);
+        va_end(args);
     } catch (...) {}
 }
 
@@ -141,12 +141,12 @@ static inline
 void d_stderr2(const char* const fmt, ...) noexcept
 {
     try {
-        ::va_list args;
-        ::va_start(args, fmt);
+        va_list args;
+        va_start(args, fmt);
         std::fprintf(stderr, "\x1b[31m");
         std::vfprintf(stderr, fmt, args);
         std::fprintf(stderr, "\x1b[0m\n");
-        ::va_end(args);
+        va_end(args);
     } catch (...) {}
 }
 

--- a/distrho/DistrhoUtils.hpp
+++ b/distrho/DistrhoUtils.hpp
@@ -33,6 +33,11 @@
 # include <stdint.h>
 #endif
 
+#if defined(DISTRHO_OS_WINDOWS) && defined(_MSC_VER)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #if defined(DISTRHO_OS_MAC) && ! defined(CARLA_OS_MAC) && ! defined(DISTRHO_PROPER_CPP11_SUPPORT)
 namespace std {
 inline float fmin(float __x, float __y)

--- a/distrho/extra/String.hpp
+++ b/distrho/extra/String.hpp
@@ -22,6 +22,11 @@
 
 #include <algorithm>
 
+#if defined(_MSC_VER)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 START_NAMESPACE_DISTRHO
 
 // -----------------------------------------------------------------------
@@ -658,7 +663,7 @@ public:
         uint i=0, j=0;
         uint charArray3[3], charArray4[4];
 
-        char strBuf[kTmpBufSize+1];
+        char* strBuf = (char*)malloc(kTmpBufSize + 1);
         strBuf[kTmpBufSize] = '\0';
         std::size_t strBufIndex = 0;
 
@@ -711,6 +716,8 @@ public:
             strBuf[strBufIndex] = '\0';
             ret += strBuf;
         }
+
+        free(strBuf);
 
         return ret;
     }

--- a/distrho/extra/String.hpp
+++ b/distrho/extra/String.hpp
@@ -656,14 +656,18 @@ public:
             "abcdefghijklmnopqrstuvwxyz"
             "0123456789+/";
 
+#ifndef _MSC_VER
         const std::size_t kTmpBufSize = std::min(d_nextPowerOf2(static_cast<uint32_t>(dataSize/3)), 65536U);
+#else
+        constexpr std::size_t kTmpBufSize = 65536U;
+#endif
 
         const uchar* bytesToEncode((const uchar*)data);
 
         uint i=0, j=0;
         uint charArray3[3], charArray4[4];
 
-        char* strBuf = (char*)malloc(kTmpBufSize + 1);
+        char strBuf[kTmpBufSize + 1];
         strBuf[kTmpBufSize] = '\0';
         std::size_t strBufIndex = 0;
 
@@ -716,8 +720,6 @@ public:
             strBuf[strBufIndex] = '\0';
             ret += strBuf;
         }
-
-        free(strBuf);
 
         return ret;
     }

--- a/distrho/extra/String.hpp
+++ b/distrho/extra/String.hpp
@@ -22,11 +22,6 @@
 
 #include <algorithm>
 
-#if defined(_MSC_VER)
-#include <basetsd.h>
-typedef SSIZE_T ssize_t;
-#endif
-
 START_NAMESPACE_DISTRHO
 
 // -----------------------------------------------------------------------

--- a/distrho/src/DistrhoDefines.h
+++ b/distrho/src/DistrhoDefines.h
@@ -55,7 +55,7 @@
 # if HAVE_CPP11_SUPPORT
 #  define DISTRHO_PROPER_CPP11_SUPPORT
 # endif
-#elif __cplusplus >= 201103L || (defined(__GNUC__) && defined(__GXX_EXPERIMENTAL_CXX0X__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 405) || __has_extension(cxx_noexcept)
+#elif __cplusplus >= 201103L || (defined(__GNUC__) && defined(__GXX_EXPERIMENTAL_CXX0X__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 405) || __has_extension(cxx_noexcept) || (defined(_MSC_VER) && _MSVC_LANG >= 201103L)
 # define DISTRHO_PROPER_CPP11_SUPPORT
 # if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) < 407 && ! defined(__clang__)) || (defined(__clang__) && ! __has_extension(cxx_override_control))
 #  define override // gcc4.7+ only

--- a/distrho/src/DistrhoDefines.h
+++ b/distrho/src/DistrhoDefines.h
@@ -74,7 +74,7 @@
 #if defined(__GNUC__)
 # define DISTRHO_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-# define DISTRHO_DEPRECATED __declspec(deprecated)
+# define DISTRHO_DEPRECATED [[deprecated]] // Note: __declspec(deprecated) it not applicable to enum members
 #else
 # define DISTRHO_DEPRECATED
 #endif

--- a/distrho/src/DistrhoDefines.h
+++ b/distrho/src/DistrhoDefines.h
@@ -74,7 +74,7 @@
 #if defined(__GNUC__)
 # define DISTRHO_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-# define DISTRHO_DEPRECATED [[deprecated]] // Note: __declspec(deprecated) it not applicable to enum members
+# define DISTRHO_DEPRECATED [[deprecated]] /* Note: __declspec(deprecated) it not applicable to enum members */
 #else
 # define DISTRHO_DEPRECATED
 #endif

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -40,7 +40,7 @@ Window*     d_lastUiWindow     = nullptr;
 // -----------------------------------------------------------------------------------------------------------
 
 #if DISTRHO_PLUGIN_HAS_EXTERNAL_UI
-UI* createUiWrapper(void* const dspPtr, const uintptr_t winId, const double scaleFactor, const char* const bundlePath)
+UI* createUiWrapper(void* dspPtr, uintptr_t winId, double scaleFactor, const char* bundlePath)
 {
     d_lastUiDspPtr    = dspPtr;
     g_nextWindowId    = winId;
@@ -54,7 +54,7 @@ UI* createUiWrapper(void* const dspPtr, const uintptr_t winId, const double scal
     return ret;
 }
 #else
-UI* createUiWrapper(void* const dspPtr, Window* const window)
+UI* createUiWrapper(void* dspPtr, Window* window)
 {
     d_lastUiDspPtr = dspPtr;
     d_lastUiWindow = window;

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -40,7 +40,7 @@ Window*     d_lastUiWindow     = nullptr;
 // -----------------------------------------------------------------------------------------------------------
 
 #if DISTRHO_PLUGIN_HAS_EXTERNAL_UI
-UI* createUiWrapper(void* dspPtr, uintptr_t winId, double scaleFactor, const char* bundlePath)
+UI* createUiWrapper(void* const dspPtr, const uintptr_t winId, const double scaleFactor, const char* const bundlePath)
 {
     d_lastUiDspPtr    = dspPtr;
     g_nextWindowId    = winId;
@@ -54,7 +54,7 @@ UI* createUiWrapper(void* dspPtr, uintptr_t winId, double scaleFactor, const cha
     return ret;
 }
 #else
-UI* createUiWrapper(void* dspPtr, Window* window)
+UI* createUiWrapper(void* const dspPtr, Window* const window)
 {
     d_lastUiDspPtr = dspPtr;
     d_lastUiWindow = window;

--- a/distrho/src/DistrhoUIInternal.hpp
+++ b/distrho/src/DistrhoUIInternal.hpp
@@ -48,9 +48,9 @@ extern Window*     d_lastUiWindow;
 // -----------------------------------------------------------------------
 
 #if DISTRHO_PLUGIN_HAS_EXTERNAL_UI
-UI* createUiWrapper(void* dspPtr, uintptr_t winId, double scaleFactor, const char* bundlePath);
+UI* createUiWrapper(void* const dspPtr, const uintptr_t winId, const double scaleFactor, const char* const bundlePath);
 #else // DISTRHO_PLUGIN_HAS_EXTERNAL_UI
-UI* createUiWrapper(void* dspPtr, Window* window);
+UI* createUiWrapper(void* const dspPtr, Window* const window);
 #endif
 
 #if !DISTRHO_PLUGIN_HAS_EXTERNAL_UI

--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -289,7 +289,7 @@ protected:
 
         // reserve atom space
         const size_t atomSize = sizeof(LV2_Atom) + msgSize;
-        char*        atomBuf = (char*)alloca(atomSize);
+        char*        atomBuf = (char*)malloc(atomSize);
         std::memset(atomBuf, 0, atomSize);
 
         // set atom info
@@ -302,6 +302,9 @@ protected:
 
         // send to DSP side
         fWriteFunction(fController, eventInPortIndex, atomSize, fURIDs.atomEventTransfer, atom);
+
+        // free atom space
+        free(atomBuf);
     }
 
 #if DISTRHO_PLUGIN_WANT_MIDI_INPUT

--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -289,7 +289,7 @@ protected:
 
         // reserve atom space
         const size_t atomSize = sizeof(LV2_Atom) + msgSize;
-        char*        atomBuf = (char*)malloc(atomSize);
+        char* const  atomBuf = (char*)malloc(atomSize);
         std::memset(atomBuf, 0, atomSize);
 
         // set atom info

--- a/distrho/src/DistrhoUILV2.cpp
+++ b/distrho/src/DistrhoUILV2.cpp
@@ -289,7 +289,7 @@ protected:
 
         // reserve atom space
         const size_t atomSize = sizeof(LV2_Atom) + msgSize;
-        char         atomBuf[atomSize];
+        char*        atomBuf = (char*)alloca(atomSize);
         std::memset(atomBuf, 0, atomSize);
 
         // set atom info

--- a/distrho/src/dssi/dssi.h
+++ b/distrho/src/dssi/dssi.h
@@ -35,6 +35,10 @@
 extern "C" {
 #endif
 
+#ifndef DSSI_PLUGIN_EXPORT
+#   define DSSI_PLUGIN_EXPORT LADSPA_PLUGIN_EXPORT
+#endif
+
 /* 
    There is a need for an API that supports hosted MIDI soft synths
    with GUIs in Linux audio applications.  In time the GMPI initiative
@@ -411,7 +415,7 @@ typedef struct _DSSI_Descriptor {
  *   of a distinct plugin type.
  */
 
-const DSSI_Descriptor *dssi_descriptor(unsigned long Index);
+DSSI_PLUGIN_EXPORT const DSSI_Descriptor *dssi_descriptor(unsigned long Index);
   
 typedef const DSSI_Descriptor *(*DSSI_Descriptor_Function)(unsigned long Index);
 

--- a/distrho/src/ladspa/ladspa.h
+++ b/distrho/src/ladspa/ladspa.h
@@ -30,6 +30,14 @@
 extern "C" {
 #endif
 
+#ifndef LADSPA_PLUGIN_EXPORT
+#   ifdef _WIN32
+#       define LADSPA_PLUGIN_EXPORT __declspec(dllexport)
+#   else
+#       define LADSPA_PLUGIN_EXPORT __attribute__((visibility("default")))
+#   endif
+#endif
+
 /*****************************************************************************/
 
 /* Overview: 
@@ -586,7 +594,7 @@ typedef struct _LADSPA_Descriptor {
    returning NULL, so the plugin count can be determined by checking
    for the least index that results in NULL being returned. */
 
-const LADSPA_Descriptor * ladspa_descriptor(unsigned long Index);
+LADSPA_PLUGIN_EXPORT const LADSPA_Descriptor * ladspa_descriptor(unsigned long Index);
 
 /* Datatype corresponding to the ladspa_descriptor() function. */
 typedef const LADSPA_Descriptor * 

--- a/utils/lv2-ttl-generator/lv2_ttl_generator.c
+++ b/utils/lv2-ttl-generator/lv2_ttl_generator.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _WIN32
@@ -62,7 +63,7 @@ int main(int argc, char* argv[])
 
     if (ttlFn != NULL)
     {
-        char basename[strlen(argv[1])+1];
+        char* basename = malloc(strlen(argv[1])+1);
 
 #ifdef TTL_GENERATOR_WINDOWS
         char* base2 = strrchr(argv[1], '\\');
@@ -87,6 +88,8 @@ int main(int argc, char* argv[])
         printf("Generate ttl data for '%s', basename: '%s'\n", argv[1], basename);
 
         ttlFn(basename);
+
+        free(basename);
     }
     else
         printf("Failed to find 'lv2_generate_ttl' function\n");

--- a/utils/lv2-ttl-generator/lv2_ttl_generator.c
+++ b/utils/lv2-ttl-generator/lv2_ttl_generator.c
@@ -34,6 +34,8 @@ typedef void (*TTL_Generator_Function)(const char* basename);
 static int isPathSeparator(char c);
 static char* makeNormalPath(const char* path);
 
+// TODO support Unicode paths on the Windows platform
+
 int main(int argc, char* argv[])
 {
     if (argc != 2)
@@ -68,18 +70,23 @@ int main(int argc, char* argv[])
 
     if (ttlFn != NULL)
     {
+        // convert the paths to a normalized form, such that path separators are
+        // replaced with '/', and duplicate separators are removed
         char* normalPath = makeNormalPath(path);
 
+        // get rid of any "./" prefixes
         path = normalPath;
         while (path[0] == '.' && path[1] == '/')
             path += 2;
 
+        // extract the file name part
         char* basename = strrchr(path, '/');
         if (basename != NULL)
             basename += 1;
         else
             basename = (char*)path;
 
+        // remove the file extension
         char* dotPos = strrchr(basename, '.');
         if (dotPos)
             *dotPos = '\0';

--- a/utils/lv2-ttl-generator/lv2_ttl_generator.c
+++ b/utils/lv2-ttl-generator/lv2_ttl_generator.c
@@ -31,6 +31,9 @@
 
 typedef void (*TTL_Generator_Function)(const char* basename);
 
+static int isPathSeparator(char c);
+static char* makeNormalPath(const char* path);
+
 int main(int argc, char* argv[])
 {
     if (argc != 2)
@@ -39,10 +42,12 @@ int main(int argc, char* argv[])
         return 1;
     }
 
+    const char* path = argv[1];
+
 #ifdef TTL_GENERATOR_WINDOWS
-    const HMODULE handle = LoadLibraryA(argv[1]);
+    const HMODULE handle = LoadLibraryA(path);
 #else
-    void* const handle = dlopen(argv[1], RTLD_LAZY);
+    void* const handle = dlopen(path, RTLD_LAZY);
 #endif
 
     if (! handle)
@@ -63,33 +68,27 @@ int main(int argc, char* argv[])
 
     if (ttlFn != NULL)
     {
-        char* basename = malloc(strlen(argv[1])+1);
+        char* normalPath = makeNormalPath(path);
 
-#ifdef TTL_GENERATOR_WINDOWS
-        char* base2 = strrchr(argv[1], '\\');
-#else
-        char* base2 = strrchr(argv[1], '/');
-#endif
-        if (base2 != NULL)
-        {
-            strcpy(basename, base2+1);
-            basename[strrchr(base2, '.')-base2-1] = '\0';
-        }
-        else if (argv[1][0] == '.' && argv[1][1] == '/')
-        {
-            strcpy(basename, argv[1]+2);
-            basename[strrchr(basename, '.')-basename] = '\0';
-        }
+        path = normalPath;
+        while (path[0] == '.' && path[1] == '/')
+            path += 2;
+
+        char* basename = strrchr(path, '/');
+        if (basename != NULL)
+            basename += 1;
         else
-        {
-            strcpy(basename, argv[1]);
-        }
+            basename = (char*)path;
 
-        printf("Generate ttl data for '%s', basename: '%s'\n", argv[1], basename);
+        char* dotPos = strrchr(basename, '.');
+        if (dotPos)
+            *dotPos = '\0';
+
+        printf("Generate ttl data for '%s', basename: '%s'\n", path, basename);
 
         ttlFn(basename);
 
-        free(basename);
+        free(normalPath);
     }
     else
         printf("Failed to find 'lv2_generate_ttl' function\n");
@@ -101,4 +100,32 @@ int main(int argc, char* argv[])
 #endif
 
     return 0;
+}
+
+static int isPathSeparator(char c)
+{
+#ifdef TTL_GENERATOR_WINDOWS
+    return c == '/' || c == '\\';
+#else
+    return c == '/';
+#endif
+}
+
+static char* makeNormalPath(const char* path)
+{
+    size_t i, j;
+    size_t len = strlen(path);
+    char* result = (char*)malloc(len + 1);
+    int isSep, wasSep = 0;
+    for (i = 0, j = 0; i < len; ++i)
+    {
+        isSep = isPathSeparator(path[i]);
+        if (!isSep)
+            result[j++] = path[i];
+        else if (!wasSep)
+            result[j++] = '/';
+        wasSep = isSep;
+    }
+    result[j] = '\0';
+    return result;
 }


### PR DESCRIPTION
Permits MSVC builds and fixes compile errors.

Note:
- adds workflow and artifacts
- currently downloads the khronos opengl headers
- lv2_ttl_generator would not generate the basename correctly
- explicit instantiations like `DGL::Rectangle<int>` produces a sea of warnings in the VS IDE.
  It dislikes that these template definitions are split in Geometry/OpenGL files.
  Such methods should be `GraphicsContext::drawRectangle` rather that `Rectangle::draw`.