### PR TITLE
Mute which output in generate-ttl.sh

### DIFF
--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # function not available on some systems
-if ! which realpath >/dev/null 2>&1; then
+if ! which realpath &>/dev/null; then
     function realpath() {
         [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
     }

--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # function not available on some systems
-if ! which realpath 2>/dev/null; then
+if ! which realpath >/dev/null 2>&1; then
     function realpath() {
         [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
     }


### PR DESCRIPTION
Was printing /usr/local/bin/realpath on Mac. Guess it is not the intention.
