### PR TITLE
Fix build when DGL_FILE_BROWSER_DISABLED is defined

### DIFF
--- a/distrho/src/DistrhoUIPrivateData.hpp
+++ b/distrho/src/DistrhoUIPrivateData.hpp
@@ -152,7 +152,7 @@ struct UI::PrivateData {
 
     ~PrivateData() noexcept
     {
-#ifndef DGL_FILE_BROWSER_DISABLED
+#if !DISTRHO_PLUGIN_HAS_EXTERNAL_UI && !defined(DGL_FILE_BROWSER_DISABLED)
         std::free(uiStateFileKeyRequest);
 #endif
     }

--- a/distrho/src/DistrhoUIPrivateData.hpp
+++ b/distrho/src/DistrhoUIPrivateData.hpp
@@ -152,7 +152,9 @@ struct UI::PrivateData {
 
     ~PrivateData() noexcept
     {
+#ifndef DGL_FILE_BROWSER_DISABLED
         std::free(uiStateFileKeyRequest);
+#endif
     }
 
     void editParamCallback(const uint32_t rindex, const bool started)


### PR DESCRIPTION
On the develop branch, the build would fail with this error when `DGL_FILE_BROWSER_DISABLED` is defined:

```
../../dpf/distrho/src/DistrhoUIPrivateData.hpp:155:19: error: ‘uiStateFileKeyRequest’ was not declared in this scope
```