### PR TITLE
Simplify custom Makefile paths

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -7,14 +7,12 @@
 # NOTE: NAME, FILES_DSP and FILES_UI must have been defined before including this file!
 
 
-ifeq ($(DPF_CUSTOM_PATH),)
+ifeq ($(DPF_PATH),)
 ifeq (,$(wildcard ../../Makefile.base.mk))
 DPF_PATH=../../dpf
 else
 DPF_PATH=../..
 endif
-else
-DPF_PATH = $(DPF_CUSTOM_PATH)
 endif
 
 include $(DPF_PATH)/Makefile.base.mk
@@ -22,21 +20,8 @@ include $(DPF_PATH)/Makefile.base.mk
 # ---------------------------------------------------------------------------------------------------------------------
 # Basic setup
 
-ifeq ($(DPF_CUSTOM_PATH),)
-TARGET_DIR = ../../bin
-BUILD_DIR = ../../build/$(NAME)
-else
-ifeq ($(DPF_CUSTOM_TARGET_DIR),)
-$(error DPF_CUSTOM_TARGET_DIR is not set)
-else
-TARGET_DIR = $(DPF_CUSTOM_TARGET_DIR)
-endif
-ifeq ($(DPF_CUSTOM_BUILD_DIR),)
-$(error DPF_CUSTOM_BUILD_DIR is not set)
-else
-BUILD_DIR = $(DPF_CUSTOM_BUILD_DIR)
-endif
-endif
+TARGET_DIR ?= ../../bin
+BUILD_DIR ?= ../../build/$(NAME)
 
 BUILD_C_FLAGS   += -I.
 BUILD_CXX_FLAGS += -I. -I$(DPF_PATH)/distrho -I$(DPF_PATH)/dgl

--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -20,8 +20,16 @@ include $(DPF_PATH)/Makefile.base.mk
 # ---------------------------------------------------------------------------------------------------------------------
 # Basic setup
 
-TARGET_DIR ?= ../../bin
-BUILD_DIR ?= ../../build/$(NAME)
+ifeq ($(DPF_TARGET_DIR),)
+TARGET_DIR = ../../bin
+else
+TARGET_DIR = $(DPF_TARGET_DIR)
+endif
+ifeq ($(DPF_BUILD_DIR),)
+BUILD_DIR = ../../build/$(NAME)
+else
+BUILD_DIR = $(DPF_BUILD_DIR)
+endif
 
 BUILD_C_FLAGS   += -I.
 BUILD_CXX_FLAGS += -I. -I$(DPF_PATH)/distrho -I$(DPF_PATH)/dgl


### PR DESCRIPTION
After fiddling a lot with my own Makefiles and learning some more from make, realized PR https://github.com/DISTRHO/DPF/pull/250 can be reworked in a more elegant / less obtrusive way by simply leveraging operator `?=` at the appropriate places.

This almost reverts the Makefile.plugins.mk to its pre #250 version while retaining that PR functionality.