### PR TITLE
Workaround for plugin window size on Mac Retina

### DIFF
--- a/distrho/DistrhoUI.hpp
+++ b/distrho/DistrhoUI.hpp
@@ -54,6 +54,10 @@ END_NAMESPACE_DGL
 
 START_NAMESPACE_DISTRHO
 
+#ifdef DISTRHO_OS_MAC
+float getMacMainScreenBackingScaleFactor();
+#endif
+
 /* ------------------------------------------------------------------------------------------------------------
  * DPF UI */
 

--- a/distrho/DistrhoUI_macOS.mm
+++ b/distrho/DistrhoUI_macOS.mm
@@ -32,4 +32,15 @@
 #define PuglWindowDelegate DISTRHO_MACOS_NAMESPACE_MACRO(DGL_NAMESPACE, PUGL_NAMESPACE, WindowDelegate)
 #define PuglWrapperView    DISTRHO_MACOS_NAMESPACE_MACRO(DGL_NAMESPACE, PUGL_NAMESPACE, WrapperView)
 
+#import <AppKit/Appkit.h>
+
 #import "src/pugl.mm"
+
+START_NAMESPACE_DISTRHO
+
+float getMacMainScreenBackingScaleFactor()
+{
+    return (float)[NSScreen mainScreen].backingScaleFactor;
+}
+
+END_NAMESPACE_DISTRHO

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -184,10 +184,6 @@ void UI::uiFileBrowserSelected(const char*)
 /* ------------------------------------------------------------------------------------------------------------
  * UI Resize Handling, internal */
 
-# if DISTRHO_OS_MAC
-extern float getMacMainScreenBackingScaleFactor();
-# endif // DISTRHO_OS_MAC
-
 void UI::onResize(const ResizeEvent& ev)
 {
     UIWidget::onResize(ev);

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -184,12 +184,23 @@ void UI::uiFileBrowserSelected(const char*)
 /* ------------------------------------------------------------------------------------------------------------
  * UI Resize Handling, internal */
 
+# if DISTRHO_OS_MAC
+extern float getMacMainScreenBackingScaleFactor();
+# endif // DISTRHO_OS_MAC
+
 void UI::onResize(const ResizeEvent& ev)
 {
     UIWidget::onResize(ev);
 
+# if DISTRHO_OS_MAC
+    float k = getMacMainScreenBackingScaleFactor();
+    const uint width = ev.size.getWidth() / k;
+    const uint height = ev.size.getHeight() / k;
+# else
     const uint width = ev.size.getWidth();
     const uint height = ev.size.getHeight();
+# endif // DISTRHO_OS_MAC
+
     uiData->setSizeCallback(width, height);
 }
 #endif // !DISTRHO_PLUGIN_HAS_EXTERNAL_UI


### PR DESCRIPTION
This is a patch for https://github.com/DISTRHO/DPF/issues/291. It is far from perfect, for example it assumes plugin windows are displayed on the main screen. Have been testing a similar solution for a while in my plugins and could not find negative side effects.
