### PR TITLE
Rework PR #302 in a cleaner way

### DIFF
--- a/dgl/src/ApplicationPrivateData.cpp
+++ b/dgl/src/ApplicationPrivateData.cpp
@@ -64,6 +64,11 @@ Application::PrivateData::PrivateData(const bool standalone)
 #ifdef HAVE_X11
     sofdFileDialogSetup(world);
 #endif
+
+#ifdef DISTRHO_OS_MAC
+    if (standalone)
+        puglMacOSActivateApp();
+#endif
 }
 
 Application::PrivateData::~PrivateData()

--- a/dgl/src/pugl.cpp
+++ b/dgl/src/pugl.cpp
@@ -391,6 +391,15 @@ bool puglMacOSFilePanelOpen(PuglView* const view,
 
     return true;
 }
+
+// --------------------------------------------------------------------------------------------------------------------
+// macOS specific, allow standalone window to gain focus
+
+void puglMacOSActivateApp()
+{
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp activateIgnoringOtherApps:YES];
+}
 #endif
 
 #ifdef DISTRHO_OS_WINDOWS

--- a/dgl/src/pugl.hpp
+++ b/dgl/src/pugl.hpp
@@ -90,6 +90,10 @@ puglFallbackOnResize(PuglView* view);
 // macOS specific, setup file browser dialog
 typedef void (*openPanelCallback)(PuglView* view, const char* path);
 bool puglMacOSFilePanelOpen(PuglView* view, const char* startDir, const char* title, uint flags, openPanelCallback callback);
+
+// macOS specific, allow standalone window to gain focus
+PUGL_API void
+puglMacOSActivateApp();
 #endif
 
 #ifdef DISTRHO_OS_WINDOWS


### PR DESCRIPTION
Replaces https://github.com/DISTRHO/DPF/pull/302

- Patch implementation moved to pugl.mm alongside other platform-specific code
- Renamed function to follow existing convention
- Avoid unnecessary new file and changes in makefiles

This update will become obsolete but safe to keep once DPF provides application bundles for the standalone JACK target.
