### PR TITLE
Partial UI_TYPE=external support on Windows

### DIFF
--- a/distrho/extra/ExternalWindow.hpp
+++ b/distrho/extra/ExternalWindow.hpp
@@ -19,9 +19,7 @@
 
 #include "String.hpp"
 
-#ifdef DISTRHO_OS_WINDOWS
-# error Unsupported platform!
-#else
+#ifndef DISTRHO_OS_WINDOWS
 # include <cerrno>
 # include <signal.h>
 # include <sys/wait.h>
@@ -106,9 +104,10 @@ public:
     */
     virtual bool isRunning() const
     {
+#ifndef DISTRHO_OS_WINDOWS
         if (ext.inUse)
             return ext.isRunning();
-
+#endif
         return isVisible();
     }
 
@@ -119,7 +118,11 @@ public:
     */
     virtual bool isQuitting() const
     {
+#ifndef DISTRHO_OS_WINDOWS
         return ext.inUse ? ext.isQuitting : pData.isQuitting;
+#else
+        return pData.isQuitting;
+#endif
     }
 
    /**
@@ -259,9 +262,10 @@ public:
     {
         pData.isQuitting = true;
         hide();
-
+#ifndef DISTRHO_OS_WINDOWS
         if (ext.inUse)
             terminateAndWaitForExternalProcess();
+#endif
     }
 
    /**
@@ -357,15 +361,24 @@ protected:
 
     bool startExternalProcess(const char* args[])
     {
+#ifndef DISTRHO_OS_WINDOWS
         ext.inUse = true;
 
         return ext.start(args);
+#else
+        (void)args;
+        return false; // TODO
+#endif
     }
 
     void terminateAndWaitForExternalProcess()
     {
+#ifndef DISTRHO_OS_WINDOWS
         ext.isQuitting = true;
         ext.terminateAndWait();
+#else
+        // TODO
+#endif
     }
 
    /* --------------------------------------------------------------------------------------------------------
@@ -414,6 +427,7 @@ private:
     friend class PluginWindow;
     friend class UI;
 
+#ifndef DISTRHO_OS_WINDOWS
     struct ExternalProcess {
         bool inUse;
         bool isQuitting;
@@ -510,6 +524,7 @@ private:
             }
         }
     } ext;
+#endif
 
     struct PrivateData {
         uintptr_t parentWindowHandle;

--- a/examples/EmbedExternalUI/EmbedExternalExampleUI.cpp
+++ b/examples/EmbedExternalUI/EmbedExternalExampleUI.cpp
@@ -347,7 +347,7 @@ protected:
 
         [pool release];
 #elif defined(DISTRHO_OS_WINDOWS)
-        MSG msg;
+        /*MSG msg;
         if (! ::PeekMessage(&msg, nullptr, 0, 0, PM_NOREMOVE))
             return true;
 
@@ -358,7 +358,7 @@ protected:
 
             //TranslateMessage(&msg);
             DispatchMessage(&msg);
-        }
+        }*/
 #else
         if (fDisplay == nullptr)
             return;


### PR DESCRIPTION
This patch allows external UI plugins to build on Windows while external implementation is completed.

To be fair support has always been there, it was disabled likely because external processes are not implemented for Win32 yet. In my case I don't need such, only a raw HWND to stick something on top, everything happens in-process.

Plugin target works (only tested VST2), standalone is missing from the EmbedExternalUI example.

There are some glitches while resizing but the whole resizing things needs to be revised for all platforms, I know external UI is still WIP  :) 

