### PR TITLE
macOS: don't include pugl.mm for external UIs

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -89,8 +89,10 @@ endif
 OBJS_DSP = $(FILES_DSP:%=$(BUILD_DIR)/%.o)
 OBJS_UI  = $(FILES_UI:%=$(BUILD_DIR)/%.o)
 
+ifneq ($(UI_TYPE),external)
 ifeq ($(MACOS),true)
 OBJS_UI += $(BUILD_DIR)/DistrhoUI_macOS_$(NAME).mm.o
+endif
 endif
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
On macOS: don't include pugl.mm for external UIs