### PR TITLE
Fix source comment typos

### DIFF
--- a/dgl/OpenGL.hpp
+++ b/dgl/OpenGL.hpp
@@ -93,7 +93,7 @@ GLenum asOpenGLImageFormat(const ImageFormat format)
    OpenGL Image class.
 
    This is an Image class that handles raw image data in pixels.
-   You can init the image data on the contructor or later on by calling loadFromMemory().
+   You can init the image data on the constructor or later on by calling loadFromMemory().
 
    To generate raw data useful for this class see the utils/png2rgba.py script.
    Be careful when using a PNG without alpha channel, for those the format is 'GL_BGR'

--- a/dgl/src/nanovg/nanovg_gl.h
+++ b/dgl/src/nanovg/nanovg_gl.h
@@ -694,7 +694,7 @@ static int glnvg__renderCreate(void* uptr, void* otherUptr)   // Share the textu
 		"		color *= strokeAlpha * scissor;\n"
 		"		result = color;\n"
 		"	} else if (type == 1) {		// Image\n"
-		"		// Calculate color fron texture\n"
+		"		// Calculate color from texture\n"
 		"		vec2 pt = (paintMat * vec3(fpos,1.0)).xy / extent;\n"
 		"#ifdef NANOVG_GL3\n"
 		"		vec4 color = texture(tex, pt);\n"

--- a/dgl/src/nanovg/stb_truetype.h
+++ b/dgl/src/nanovg/stb_truetype.h
@@ -647,7 +647,7 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h
 STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip);
 // If skip != 0, this tells stb_truetype to skip any codepoints for which
 // there is no corresponding glyph. If skip=0, which is the default, then
-// codepoints without a glyph recived the font's "missing character" glyph,
+// codepoints without a glyph received the font's "missing character" glyph,
 // typically an empty box by convention.
 
 STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph,  // same data as above

--- a/dgl/src/pugl-custom/pugl.h
+++ b/dgl/src/pugl-custom/pugl.h
@@ -139,7 +139,7 @@ typedef void (*PuglDisplayFunc)(PuglView* view);
 
 /**
    A function called when a key is pressed or released.
-   @param view The view the event occured in.
+   @param view The view the event occurred in.
    @param press True if the key was pressed, false if released.
    @param key Unicode point of the key pressed.
    @return 0 if event was handled, otherwise send event to parent window.
@@ -148,7 +148,7 @@ typedef int (*PuglKeyboardFunc)(PuglView* view, bool press, uint32_t key);
 
 /**
    A function called when the pointer moves.
-   @param view The view the event occured in.
+   @param view The view the event occurred in.
    @param x The window-relative x coordinate of the pointer.
    @param y The window-relative y coordinate of the pointer.
 */
@@ -156,7 +156,7 @@ typedef void (*PuglMotionFunc)(PuglView* view, int x, int y);
 
 /**
    A function called when a mouse button is pressed or released.
-   @param view The view the event occured in.
+   @param view The view the event occurred in.
    @param button The button number (1 = left, 2 = middle, 3 = right).
    @param press True if the key was pressed, false if released.
    @param x The window-relative x coordinate of the pointer.
@@ -205,7 +205,7 @@ typedef void (*PuglScrollFunc)(PuglView* view, int x, int y, float dx, float dy)
    This callback allows the use of keys that do not have unicode points.
    Note that some are non-printable keys.
 
-   @param view The view the event occured in.
+   @param view The view the event occurred in.
    @param press True if the key was pressed, false if released.
    @param key The key pressed.
    @return 0 if event was handled, otherwise send event to parent window.
@@ -215,7 +215,7 @@ typedef int (*PuglSpecialFunc)(PuglView* view, bool press, PuglKey key);
 /**
    A function called when a filename is selected via file-browser.
 
-   @param view The view the event occured in.
+   @param view The view the event occurred in.
    @param filename The selected file name or NULL if the dialog was canceled.
 */
 typedef void (*PuglFileSelectedFunc)(PuglView* view, const char* filename);

--- a/dgl/src/pugl-custom/pugl_win.cpp
+++ b/dgl/src/pugl-custom/pugl_win.cpp
@@ -149,7 +149,7 @@ puglCreateWindow(PuglView* view, const char* title)
 	if (view->user_resizable) {
 		winFlags |= WS_SIZEBOX;
 		if (view->min_width > 0 && view->min_height > 0) {
-			// Adjust the minimum window size to accomodate requested view size
+			// Adjust the minimum window size to accommodate requested view size
 			RECT mr = { 0, 0, view->min_width, view->min_height };
 			AdjustWindowRectEx(&mr, view->parent ? WS_CHILD : winFlags, FALSE, WS_EX_TOPMOST);
 			view->min_width  = mr.right - mr.left;
@@ -157,7 +157,7 @@ puglCreateWindow(PuglView* view, const char* title)
 		}
 	}
 
-	// Adjust the window size to accomodate requested view size
+	// Adjust the window size to accommodate requested view size
 	RECT wr = { 0, 0, view->width, view->height };
 	AdjustWindowRectEx(&wr, view->parent ? WS_CHILD : winFlags, FALSE, WS_EX_TOPMOST);
 

--- a/dgl/src/pugl-custom/pugl_x11.c
+++ b/dgl/src/pugl-custom/pugl_x11.c
@@ -52,7 +52,7 @@
  */
 //#define PUGL_GRAB_FOCUS
 
-/* show messages during initalization
+/* show messages during initialization
  */
 //#define PUGL_VERBOSE
 

--- a/distrho/DistrhoPlugin.hpp
+++ b/distrho/DistrhoPlugin.hpp
@@ -120,7 +120,7 @@ static const uint32_t kParameterIsLogarithmic = 0x08;
    The other exception is with parameter change requests, see Plugin::requestParameterValueChange().@n
    Outputs are changed by the plugin and never modified by the host.
 
-   If you are targetting VST2, make sure to order your parameters so that all inputs are before any outputs.
+   If you are targeting VST2, make sure to order your parameters so that all inputs are before any outputs.
  */
 static const uint32_t kParameterIsOutput = 0x10;
 

--- a/distrho/DistrhoPluginUtils.hpp
+++ b/distrho/DistrhoPluginUtils.hpp
@@ -125,7 +125,7 @@ struct AudioMidiSyncHelper
     }
 
     /**
-       Process a batch of events untill no more are available.
+       Process a batch of events until no more are available.
        You must not read any more values from this class after this function returns false.
     */
     bool nextEvent()

--- a/distrho/DistrhoUI.hpp
+++ b/distrho/DistrhoUI.hpp
@@ -97,7 +97,7 @@ public:
       There are situations where an UI supports resizing but the plugin host does not, so this could return false.
 
       You might want to add a resize handle for such cases, so the user is still allowed to resize the window.
-      (programatically resizing a window is always possible, but the same is not true for the window manager)
+      (programmatically resizing a window is always possible, but the same is not true for the window manager)
     */
     bool isResizable() const noexcept;
 
@@ -351,14 +351,14 @@ protected:
 #if DISTRHO_PLUGIN_HAS_EXTERNAL_UI
    /**
       External Window resize function, called when the window is resized.
-      This is overriden here so the host knows when the UI is resized by you.
+      This is overridden here so the host knows when the UI is resized by you.
       @see ExternalWindow::sizeChanged(uint,uint)
     */
     void sizeChanged(uint width, uint height) override;
 #else
    /**
       Widget resize function, called when the widget is resized.
-      This is overriden here so the host knows when the UI is resized by you.
+      This is overridden here so the host knows when the UI is resized by you.
       @see Widget::onResize(const ResizeEvent&)
     */
     void onResize(const ResizeEvent& ev) override;

--- a/distrho/extra/ExternalWindow.hpp
+++ b/distrho/extra/ExternalWindow.hpp
@@ -95,7 +95,7 @@ public:
     }
 
    /* --------------------------------------------------------------------------------------------------------
-    * ExternalWindow specific calls - Host side calls that you can reimplement for fine-grained funtionality */
+    * ExternalWindow specific calls - Host side calls that you can reimplement for fine-grained functionality */
 
    /**
       Check if main-loop is running.
@@ -127,7 +127,7 @@ public:
 
    /**
       Get the "native" window handle.
-      This can be reimplemented in order to pass the native window to hosts that can use such informaton.
+      This can be reimplemented in order to pass the native window to hosts that can use such information.
 
       Returned value type depends on the platform:
        - HaikuOS: This is a pointer to a `BView`.

--- a/distrho/extra/ScopedPointer.hpp
+++ b/distrho/extra/ScopedPointer.hpp
@@ -68,7 +68,7 @@ START_NAMESPACE_DISTRHO
     can use the release() method.
 
     Something to note is the main difference between this class and the std::auto_ptr class,
-    which is that ScopedPointer provides a cast-to-object operator, wheras std::auto_ptr
+    which is that ScopedPointer provides a cast-to-object operator, whereas std::auto_ptr
     requires that you always call get() to retrieve the pointer. The advantages of providing
     the cast is that you don't need to call get(), so can use the ScopedPointer in pretty much
     exactly the same way as a raw pointer. The disadvantage is that the compiler is free to

--- a/distrho/extra/sofd/libsofd.c
+++ b/distrho/extra/sofd/libsofd.c
@@ -461,8 +461,8 @@ static FibButton    *_btns[] = {&_btn_places, &_btn_filter, &_btn_hidden, &_btn_
 static int (*_fib_filter_function)(const char *filename);
 
 /* hardcoded layout */
-#define DSEP 6 // px; horiz space beween elements, also l+r margin for file-list
-#define PSEP 4 // px; horiz space beween paths
+#define DSEP 6 // px; horiz space between elements, also l+r margin for file-list
+#define PSEP 4 // px; horiz space between paths
 #define FILECOLUMN (17 * _fib_dir_indent) //px;  min width of file-column
 #define LISTTOP 2.7 //em;  top of the file-browser list
 #define LISTBOT 4.75 //em;  bottom of the file-browers list
@@ -617,7 +617,7 @@ static void fib_expose (Display *dpy, Window realwin) {
 	int t_s = FAREATEXTL * _scalefactor + fsel_width;
 	int t_t = FAREATEXTL * _scalefactor + fsel_width;
 
-	// check which colums can be visible
+	// check which columns can be visible
 	// depending on available width of window.
 	_columns = 0;
 	if (fsel_width > FILECOLUMN + _fib_font_size_width + _fib_font_time_width) {

--- a/distrho/extra/sofd/libsofd.h
+++ b/distrho/extra/sofd/libsofd.h
@@ -37,8 +37,8 @@ extern "C" {
 /** open a file select dialog
  * @param dpy X Display connection
  * @param parent (optional) if not NULL, become transient for given window
- * @param x if >0 set explict initial width of the window
- * @param y if >0 set explict initial height of the window
+ * @param x if >0 set explicit initial width of the window
+ * @param y if >0 set explicit initial height of the window
  * @return 0 on success
  */
 int x_fib_show (Display *dpy, Window parent, int x, int y, double scalefactor);

--- a/distrho/src/jackbridge/rtaudio/RtAudio.cpp
+++ b/distrho/src/jackbridge/rtaudio/RtAudio.cpp
@@ -267,7 +267,7 @@ RtAudio :: RtAudio( RtAudio::Api api )
   // It should not be possible to get here because the preprocessor
   // definition __RTAUDIO_DUMMY__ is automatically defined if no
   // API-specific definitions are passed to the compiler. But just in
-  // case something weird happens, we'll thow an error.
+  // case something weird happens, we'll throw an error.
   std::string errorText = "\nRtAudio: no compiled API support found ... critical error!!\n\n";
   throw( RtAudioError( errorText, RtAudioError::UNSPECIFIED ) );
 }
@@ -6894,7 +6894,7 @@ void RtApiDs :: callbackEvent()
     if ( stream_.mode == DUPLEX ) {
       if ( safeReadPointer < endRead ) {
         if ( duplexPrerollBytes <= 0 ) {
-          // Pre-roll time over. Be more agressive.
+          // Pre-roll time over. Be more aggressive.
           int adjustment = endRead-safeReadPointer;
 
           handle->xrun[1] = true;
@@ -8328,7 +8328,7 @@ void RtApiAlsa :: callbackEvent()
     }
 
     if ( result < (int) stream_.bufferSize ) {
-      // Either an error or overrun occured.
+      // Either an error or overrun occurred.
       if ( result == -EPIPE ) {
         snd_pcm_state_t state = snd_pcm_state( handle[1] );
         if ( state == SND_PCM_STATE_XRUN ) {
@@ -8398,7 +8398,7 @@ void RtApiAlsa :: callbackEvent()
     }
 
     if ( result < (int) stream_.bufferSize ) {
-      // Either an error or underrun occured.
+      // Either an error or underrun occurred.
       if ( result == -EPIPE ) {
         snd_pcm_state_t state = snd_pcm_state( handle[0] );
         if ( state == SND_PCM_STATE_XRUN ) {

--- a/distrho/src/jackbridge/rtaudio/RtAudio.h
+++ b/distrho/src/jackbridge/rtaudio/RtAudio.h
@@ -226,12 +226,12 @@ class RTAUDIO_DLL_PUBLIC RtAudioError : public std::runtime_error
     UNSPECIFIED,       /*!< The default, unspecified error type. */
     NO_DEVICES_FOUND,  /*!< No devices found on system. */
     INVALID_DEVICE,    /*!< An invalid device ID was specified. */
-    MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+    MEMORY_ERROR,      /*!< An error occurred during memory allocation. */
     INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
     INVALID_USE,       /*!< The function was called incorrectly. */
-    DRIVER_ERROR,      /*!< A system driver error occured. */
-    SYSTEM_ERROR,      /*!< A system error occured. */
-    THREAD_ERROR       /*!< A thread error occured. */
+    DRIVER_ERROR,      /*!< A system driver error occurred. */
+    SYSTEM_ERROR,      /*!< A system error occurred. */
+    THREAD_ERROR       /*!< A thread error occurred. */
   };
 
   //! The constructor.
@@ -309,7 +309,7 @@ class RTAUDIO_DLL_PUBLIC RtAudio
     RtAudioFormat nativeFormats{};  /*!< Bit mask of supported data formats. */
   };
 
-  //! The structure for specifying input or ouput stream parameters.
+  //! The structure for specifying input or output stream parameters.
   struct StreamParameters {
     unsigned int deviceId{};     /*!< Device index (0 to getDeviceCount() - 1). */
     unsigned int nChannels{};    /*!< Number of channels. */
@@ -514,7 +514,7 @@ class RTAUDIO_DLL_PUBLIC RtAudio
            lowest allowable value is used.  The actual value used is
            returned via the structure argument.  The parameter is API dependent.
     \param errorCallback A client-defined function that will be invoked
-           when an error has occured.
+           when an error has occurred.
   */
   void openStream( RtAudio::StreamParameters *outputParameters,
                    RtAudio::StreamParameters *inputParameters,
@@ -891,7 +891,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( AudioDeviceID deviceId,
                       const AudioBufferList *inBufferList,
                       const AudioBufferList *outBufferList );
@@ -926,7 +926,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( unsigned long nframes );
 
   private:
@@ -960,7 +960,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( long bufferIndex );
 
   private:
@@ -997,7 +997,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1070,7 +1070,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1102,7 +1102,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1135,7 +1135,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:

--- a/distrho/src/lv2/atom-forge.h
+++ b/distrho/src/lv2/atom-forge.h
@@ -287,7 +287,7 @@ lv2_atom_forge_set_sink(LV2_Atom_Forge*            forge,
 /**
    Write raw output.  This is used internally, but is also useful for writing
    atom types not explicitly supported by the forge API.  Note the caller is
-   responsible for ensuring the output is approriately padded.
+   responsible for ensuring the output is appropriately padded.
 */
 static inline LV2_Atom_Forge_Ref
 lv2_atom_forge_raw(LV2_Atom_Forge* forge, const void* data, uint32_t size)

--- a/distrho/src/lv2/dynmanifest.h
+++ b/distrho/src/lv2/dynmanifest.h
@@ -77,7 +77,7 @@ int lv2_dyn_manifest_open(LV2_Dyn_Manifest_Handle *  handle,
 
    <http://www.example.com/plugin/uri> a lv2:Plugin .
 
-   The objects that are elegible for exposure are those that would need to be
+   The objects that are eligible for exposure are those that would need to be
    represented by a subject node in a static manifest.
 
    @param handle Dynamic manifest generator handle.

--- a/distrho/src/lv2/lv2_external_ui.h
+++ b/distrho/src/lv2/lv2_external_ui.h
@@ -40,7 +40,7 @@ extern "C" {
  */
 typedef struct _LV2_External_UI_Widget {
   /**
-   * Host calls this function regulary. UI library implementing the
+   * Host calls this function regularly. UI library implementing the
    * callback may do IPC or redraw the UI.
    *
    * @param _this_ the UI context

--- a/distrho/src/lv2/ui.h
+++ b/distrho/src/lv2/ui.h
@@ -198,7 +198,7 @@ typedef struct _LV2UI_Descriptor {
 
 	   By default, the host should only call this function for lv2:ControlPort
 	   inputs.  However, the UI can request updates for other ports statically
-	   with ui:portNotification or dynamicaly with ui:portSubscribe.
+	   with ui:portNotification or dynamically with ui:portSubscribe.
 
 	   The UI MUST NOT retain any reference to `buffer` after this function
 	   returns, it is only valid for the duration of the call.

--- a/examples/Meters/ExamplePluginMeters.cpp
+++ b/examples/Meters/ExamplePluginMeters.cpp
@@ -193,7 +193,7 @@ protected:
     */
     void setParameterValue(uint32_t index, float value) override
     {
-        // this is only called for input paramters, and we only have one of those.
+        // this is only called for input parameters, and we only have one of those.
         if (index != 0) return;
 
         fColor = value;

--- a/examples/Metronome/README.md
+++ b/examples/Metronome/README.md
@@ -5,7 +5,7 @@ This example will show tempo sync in DPF.<br/>
 This plugin will output a sine wave at the start of every beat.<br/>
 The pitch of sine wave is 1 octave higher at the start of every bar.<br/>
 
-4 parameters are avaialble:
+4 parameters are available:
 
 - Gain
 - Decay time


### PR DESCRIPTION
Found via `codespell -q 3 -S ./dgl/src/pugl-upstream`