### PR TITLE
cmake: Generate the VST as a bundle on macOS

### DIFF
--- a/cmake/DPF-plugin.cmake
+++ b/cmake/DPF-plugin.cmake
@@ -317,6 +317,17 @@ function(dpf__build_vst2 NAME DGL_LIBRARY)
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/obj/vst2/$<0:>"
     OUTPUT_NAME "${NAME}-vst2"
     PREFIX "")
+  if(APPLE)
+    set_target_properties("${NAME}-vst2" PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin/${NAME}.vst/Contents/MacOS/$<0:>"
+      OUTPUT_NAME "${NAME}"
+      SUFFIX "")
+    set(INFO_PLIST_PROJECT_NAME "${NAME}")
+    configure_file("${DPF_ROOT_DIR}/utils/plugin.vst/Contents/Info.plist"
+      "${PROJECT_BINARY_DIR}/bin/${NAME}.vst/Contents/Info.plist" @ONLY)
+    file(COPY "${DPF_ROOT_DIR}/utils/plugin.vst/Contents/PkgInfo"
+      DESTINATION "${PROJECT_BINARY_DIR}/bin/${NAME}.vst/Contents")
+  endif()
 endfunction()
 
 # dpf__add_dgl_cairo

--- a/utils/generate-vst-bundles.sh
+++ b/utils/generate-vst-bundles.sh
@@ -19,7 +19,7 @@ for i in $PLUGINS; do
   cp -r ${DPF_DIR}/utils/plugin.vst/ ${BUNDLE}.vst
   mv ${i} ${BUNDLE}.vst/Contents/MacOS/${BUNDLE}
   rm -f ${BUNDLE}.vst/Contents/MacOS/deleteme
-  sed -i -e "s/X-PROJECTNAME-X/${BUNDLE}/" ${BUNDLE}.vst/Contents/Info.plist
+  sed -i -e "s/@INFO_PLIST_PROJECT_NAME@/${BUNDLE}/" ${BUNDLE}.vst/Contents/Info.plist
   rm -f ${BUNDLE}.vst/Contents/Info.plist-e
 done
 

--- a/utils/plugin.vst/Contents/Info.plist
+++ b/utils/plugin.vst/Contents/Info.plist
@@ -5,11 +5,11 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>English</string>
         <key>CFBundleExecutable</key>
-        <string>X-PROJECTNAME-X</string>
+        <string>@INFO_PLIST_PROJECT_NAME@</string>
         <key>CFBundleIconFile</key>
         <string></string>
         <key>CFBundleIdentifier</key>
-        <string>studio.kx.distrho.X-PROJECTNAME-X</string>
+        <string>studio.kx.distrho.@INFO_PLIST_PROJECT_NAME@</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundlePackageType</key>


### PR DESCRIPTION
This will make cmake generate the macOS VST directly in the form of a bundle.
A script will not be necessary.
Renamed `X-PROJECTNAME-X`, to make it more practical in this case, and tested both builds on macOS.