### PR TITLE
Prevent some compilation warnings on MinGW

### DIFF
--- a/dgl/src/pugl.cpp
+++ b/dgl/src/pugl.cpp
@@ -213,10 +213,17 @@ double puglGetDesktopScaleFactor(const PuglView* const view)
         typedef HRESULT(WINAPI* PFN_GetProcessDpiAwareness)(HANDLE, DWORD*);
         typedef HRESULT(WINAPI* PFN_GetScaleFactorForMonitor)(HMONITOR, DWORD*);
 
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-function-type"
+# endif
         const PFN_GetProcessDpiAwareness GetProcessDpiAwareness
             = (PFN_GetProcessDpiAwareness)GetProcAddress(Shcore, "GetProcessDpiAwareness");
         const PFN_GetScaleFactorForMonitor GetScaleFactorForMonitor
             = (PFN_GetScaleFactorForMonitor)GetProcAddress(Shcore, "GetScaleFactorForMonitor");
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic pop
+# endif
 
         DWORD dpiAware = 0;
         if (GetProcessDpiAwareness && GetScaleFactorForMonitor

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -53,19 +53,22 @@ static double getDesktopScaleFactor(const uintptr_t parentWindowHandle)
         return std::max(1.0, std::atof(scale));
 
 #if defined(DISTRHO_OS_WINDOWS)
-# if defined(__GNUC__) && (__GNUC__ >= 9)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wcast-function-type"
-# endif
     if (const HMODULE Shcore = LoadLibraryA("Shcore.dll"))
     {
         typedef HRESULT(WINAPI* PFN_GetProcessDpiAwareness)(HANDLE, DWORD*);
         typedef HRESULT(WINAPI* PFN_GetScaleFactorForMonitor)(HMONITOR, DWORD*);
 
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-function-type"
+# endif
         const PFN_GetProcessDpiAwareness GetProcessDpiAwareness
             = (PFN_GetProcessDpiAwareness)GetProcAddress(Shcore, "GetProcessDpiAwareness");
         const PFN_GetScaleFactorForMonitor GetScaleFactorForMonitor
             = (PFN_GetScaleFactorForMonitor)GetProcAddress(Shcore, "GetScaleFactorForMonitor");
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic pop
+# endif
 
         DWORD dpiAware = 0;
         if (GetProcessDpiAwareness && GetScaleFactorForMonitor
@@ -85,9 +88,6 @@ static double getDesktopScaleFactor(const uintptr_t parentWindowHandle)
 
         FreeLibrary(Shcore);
     }
-# if defined(__GNUC__) && (__GNUC__ >= 9)
-#  pragma GCC diagnostic pop
-# endif
 #elif defined(HAVE_X11)
     ::Display* const display = XOpenDisplay(nullptr);
     DISTRHO_SAFE_ASSERT_RETURN(display != nullptr, 1.0);

--- a/distrho/src/DistrhoUI.cpp
+++ b/distrho/src/DistrhoUI.cpp
@@ -53,6 +53,10 @@ static double getDesktopScaleFactor(const uintptr_t parentWindowHandle)
         return std::max(1.0, std::atof(scale));
 
 #if defined(DISTRHO_OS_WINDOWS)
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-function-type"
+# endif
     if (const HMODULE Shcore = LoadLibraryA("Shcore.dll"))
     {
         typedef HRESULT(WINAPI* PFN_GetProcessDpiAwareness)(HANDLE, DWORD*);
@@ -81,6 +85,9 @@ static double getDesktopScaleFactor(const uintptr_t parentWindowHandle)
 
         FreeLibrary(Shcore);
     }
+# if defined(__GNUC__) && (__GNUC__ >= 9)
+#  pragma GCC diagnostic pop
+# endif
 #elif defined(HAVE_X11)
     ::Display* const display = XOpenDisplay(nullptr);
     DISTRHO_SAFE_ASSERT_RETURN(display != nullptr, 1.0);


### PR DESCRIPTION
Found this working solution https://github.com/official-stockfish/Stockfish/issues/1619#issuecomment-396776490 . There might be others...

Suppresses these warnings which are generated multiple times when compiling the examples:

```
Compiling DistrhoUIMain.cpp (JACK)
In file included from ../../distrho/DistrhoUIMain.cpp:17:
../../distrho/src/DistrhoUI.cpp: In function 'double DISTRHO::getDesktopScaleFactor(uintptr_t)':
../../distrho/src/DistrhoUI.cpp:62:15: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'PFN_GetProcessDpiAwareness' {aka 'long int (*)(void*, long unsigned int*)'} [-Wcast-function-type]
   62 |             = (PFN_GetProcessDpiAwareness)GetProcAddress(Shcore, "GetProcessDpiAwareness");
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../distrho/src/DistrhoUI.cpp:64:15: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'PFN_GetScaleFactorForMonitor' {aka 'long int (*)(HMONITOR__*, long unsigned int*)'} [-Wcast-function-type]
   64 |             = (PFN_GetScaleFactorForMonitor)GetProcAddress(Shcore, "GetScaleFactorForMonitor");
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
