### PR TITLE
Allow to build VST3 for plugins with external UI

### DIFF
--- a/distrho/src/DistrhoUIVST3.cpp
+++ b/distrho/src/DistrhoUIVST3.cpp
@@ -195,7 +195,7 @@ public:
     {
         d_stdout("onKeyDown %i %i %x\n", keychar, keycode, modifiers);
         DISTRHO_SAFE_ASSERT_INT_RETURN(keychar >= 0 && keychar < 0x7f, keychar, V3_FALSE);
-
+#if !DISTRHO_PLUGIN_HAS_EXTERNAL_UI
         using namespace DGL_NAMESPACE;
 
         // TODO
@@ -220,13 +220,16 @@ public:
 #endif
 
         return fUI.handlePluginKeyboardVST3(true, static_cast<uint>(keychar), dglcode, dglmods) ? V3_TRUE : V3_FALSE;
+#else
+        return V3_NOT_IMPLEMENTED;
+#endif // DISTRHO_PLUGIN_HAS_EXTERNAL_UI
     }
 
     v3_result onKeyUp(const int16_t keychar, const int16_t keycode, const int16_t modifiers)
     {
         d_stdout("onKeyDown %i %i %x\n", keychar, keycode, modifiers);
         DISTRHO_SAFE_ASSERT_INT_RETURN(keychar >= 0 && keychar < 0x7f, keychar, V3_FALSE);
-
+#if !DISTRHO_PLUGIN_HAS_EXTERNAL_UI
         using namespace DGL_NAMESPACE;
 
         // TODO
@@ -251,6 +254,9 @@ public:
 #endif
 
         return fUI.handlePluginKeyboardVST3(false, static_cast<uint>(keychar), dglcode, dglmods) ? V3_TRUE : V3_FALSE;
+#else
+        return V3_NOT_IMPLEMENTED;
+#endif // DISTRHO_PLUGIN_HAS_EXTERNAL_UI
     }
 
     v3_result getSize(v3_view_rect* const rect) const noexcept

--- a/examples/EmbedExternalUI/Makefile
+++ b/examples/EmbedExternalUI/Makefile
@@ -35,6 +35,7 @@ TARGETS += jack
 TARGETS += dssi
 TARGETS += lv2_sep
 TARGETS += vst2
+TARGETS += vst3
 
 all: $(TARGETS)
 


### PR DESCRIPTION
PR fixes this compilation issue:

```
In file included from ../../distrho/DistrhoUIMain.cpp:30:
../../distrho/src/DistrhoUIVST3.cpp: In member function ‘v3_result DISTRHO::UIVst3::onKeyDown(int16_t, int16_t, int16_t)’:
../../distrho/src/DistrhoUIVST3.cpp:222:20: error: ‘class DISTRHO::UIExporter’ has no member named ‘handlePluginKeyboardVST3’
  222 |         return fUI.handlePluginKeyboardVST3(true, static_cast<uint>(keychar), dglcode, dglmods) ? V3_TRUE : V3_FALSE;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~
../../distrho/src/DistrhoUIVST3.cpp: In member function ‘v3_result DISTRHO::UIVst3::onKeyUp(int16_t, int16_t, int16_t)’:
../../distrho/src/DistrhoUIVST3.cpp:253:20: error: ‘class DISTRHO::UIExporter’ has no member named ‘handlePluginKeyboardVST3’
  253 |         return fUI.handlePluginKeyboardVST3(false, static_cast<uint>(keychar), dglcode, dglmods) ? V3_TRUE : V3_FALSE;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~
make: *** [../../Makefile.plugins.mk:302: ../../build/d_embedextui/DistrhoUIMain_VST3.cpp.o] Error 1
```