### PR TITLE
Return abs. path in getBinaryFilename() Linux/Jack

### DIFF
--- a/distrho/src/DistrhoUtils.cpp
+++ b/distrho/src/DistrhoUtils.cpp
@@ -24,12 +24,8 @@
 # include <windows.h>
 #else
 # include <dlfcn.h>
+# include <limits.h>
 # include <stdlib.h>
-# ifdef DISTRHO_OS_MAC
-#  include <sys/syslimits.h>
-# else
-#  include <linux/limits.h>
-# endif
 #endif
 
 #if defined(DISTRHO_OS_WINDOWS) && !DISTRHO_IS_STANDALONE


### PR DESCRIPTION
Great work on `getBinaryFilename()` and `getPluginFormatName()`.

On Linux Ubuntu 21.10 `dli_fname` is filled with a relative path when running standalone. The expected absolute path is present when running from .so .

The man page does not state `dli_fname` is absolute https://man7.org/linux/man-pages/man3/dladdr.3.html .  There is an alternate `dladdr1()` call that does return an absolute path but since a special case is already needed I opted for a less obscure version (read `/proc/self/exe`). I am not a experienced Linux programmer maybe you want to have a look at that `dladdr1()` first as well.
