### PR TITLE
Fix issue #364

### DIFF
--- a/distrho/src/DistrhoPluginVST3.cpp
+++ b/distrho/src/DistrhoPluginVST3.cpp
@@ -1071,9 +1071,6 @@ public:
         else
         {
             fPlugin.deactivateIfNeeded();
-
-            delete[] fDummyAudioBuffer;
-            fDummyAudioBuffer = nullptr;
         }
 
         return V3_OK;


### PR DESCRIPTION
https://github.com/DISTRHO/DPF/issues/364

Deal with `fDummyAudioBuffer` lifecycle in a supposedly safer way.
