### PR TITLE
Fix make clean for vst3

### DIFF
--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -316,7 +316,7 @@ $(BUILD_DIR)/%.mm.o: %.mm
 
 clean:
 	rm -rf $(BUILD_DIR)
-	rm -rf $(TARGET_DIR)/$(NAME) $(TARGET_DIR)/$(NAME)-* $(TARGET_DIR)/$(NAME).lv2
+	rm -rf $(TARGET_DIR)/$(NAME) $(TARGET_DIR)/$(NAME)-* $(TARGET_DIR)/$(NAME).lv2 $(TARGET_DIR)/$(NAME).vst3
 
 # ---------------------------------------------------------------------------------------------------------------------
 # DGL

--- a/Makefile.plugins.mk
+++ b/Makefile.plugins.mk
@@ -316,7 +316,7 @@ $(BUILD_DIR)/%.mm.o: %.mm
 
 clean:
 	rm -rf $(BUILD_DIR)
-	rm -rf $(TARGET_DIR)/$(NAME) $(TARGET_DIR)/$(NAME)-* $(TARGET_DIR)/$(NAME).lv2 $(TARGET_DIR)/$(NAME).vst3
+	rm -rf $(TARGET_DIR)/$(NAME) $(TARGET_DIR)/$(NAME)-* $(TARGET_DIR)/$(NAME).lv2 $(TARGET_DIR)/$(NAME).vst3 $(TARGET_DIR)/$(NAME).vst
 
 # ---------------------------------------------------------------------------------------------------------------------
 # DGL


### PR DESCRIPTION
I think It makes sense to clean up .vst3 the same way .lv2 gets clean up. Or maybe I missed something. By the way thanks for vst3 support and all the work on DPF.