### PR TITLE
Fix loop variable error on LV2export

### DIFF
--- a/distrho/src/DistrhoPluginLV2export.cpp
+++ b/distrho/src/DistrhoPluginLV2export.cpp
@@ -1632,7 +1632,7 @@ void lv2_generate_ttl(const char* const basename)
 
                 presetString += "        <";
 
-                if (plugin.getStateHints(i) & kStateIsHostReadable)
+                if (plugin.getStateHints(j) & kStateIsHostReadable)
                     presetString += DISTRHO_PLUGIN_URI "#";
                 else
                     presetString += DISTRHO_PLUGIN_LV2_STATE_PREFIX;


### PR DESCRIPTION
Location: "Write preset.ttl" section. Index of program was erroneously passed to plugin.getStateHints(), which made LV2export misbehave.