### PR TITLE
Add missing `break` to CLAP event switch case

### DIFF
--- a/distrho/src/DistrhoPluginCLAP.cpp
+++ b/distrho/src/DistrhoPluginCLAP.cpp
@@ -977,6 +977,7 @@ public:
                     case CLAP_EVENT_PARAM_GESTURE_BEGIN:
                     case CLAP_EVENT_PARAM_GESTURE_END:
                     case CLAP_EVENT_TRANSPORT:
+                        break;
                     case CLAP_EVENT_MIDI:
                         DISTRHO_SAFE_ASSERT_UINT2_BREAK(event->size == sizeof(clap_event_midi_t),
                                                         event->size, sizeof(clap_event_midi_t));


### PR DESCRIPTION
Stops param and transport events from flowing into the MIDI case.