### PR TITLE
Fix crash on CLAP hosts that do not implement latency extension

### DIFF
--- a/distrho/src/DistrhoPluginCLAP.cpp
+++ b/distrho/src/DistrhoPluginCLAP.cpp
@@ -1832,6 +1832,7 @@ private:
             DISTRHO_SAFE_ASSERT_RETURN(host->request_restart != nullptr, false);
             DISTRHO_SAFE_ASSERT_RETURN(host->request_callback != nullptr, false);
             latency = static_cast<const clap_host_latency_t*>(host->get_extension(host, CLAP_EXT_LATENCY));
+            DISTRHO_SAFE_ASSERT_RETURN(latency != nullptr, false);
             threadCheck = static_cast<const clap_host_thread_check_t*>(host->get_extension(host, CLAP_EXT_THREAD_CHECK));
            #endif
             return true;


### PR DESCRIPTION
When DISTRHO_PLUGIN_WANT_LATENCY == 1, CLAP plugins assume the host implements the latency CLAP extension and do not check whether the pointer to the host's latency extension is nullptr. As a result, a null pointer dereference can occur when the host proceeds to use the plugin.

This PR makes plugins that require the latency extension to check that hosts actually implement it, and if this requirement is not met, plugin initialization will fail.