### PR TITLE
fix: TTL generator exe path when building for windows

### DIFF
--- a/utils/generate-ttl.sh
+++ b/utils/generate-ttl.sh
@@ -23,7 +23,7 @@ fi
 PWD="$(dirname "${0}")"
 
 if [ -f "${PWD}/lv2_ttl_generator.exe" ]; then
-  GEN="${PWD}/lv2_ttl_generator.exe"
+  GEN="$(realpath ${PWD}/lv2_ttl_generator.exe)"
   EXT=dll
 else
   GEN="$(realpath ${PWD}/lv2_ttl_generator)"


### PR DESCRIPTION
Fixes failing build when using using `make` to build for windows, due to path to `utils/lv2_ttl_generator.exe` being relative, but the `generate-ttl.sh` script changes working directory.

```
make -C dpf/utils/lv2-ttl-generator WINDOWS=true
make[1]: Entering directory '/home/chris/work/ykchorus/dpf/utils/lv2-ttl-generator'
i686-w64-mingw32-gcc lv2_ttl_generator.c -Wall -Wextra -pipe -MD -MP -fno-gnu-unique -posix -D__STDC_FORMAT_MACROS=1 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -DNDEBUG -O3 -ffast-math -fdata-sections -ffunction-sections -mtune=generic -msse -msse2 -mfpmath=sse -fvisibility=hidden -std=gnu99 -DPTW32_STATIC_LIB -Werror -o ../lv2_ttl_generator.exe -fdata-sections -ffunction-sections -Wl,-O1,--as-needed,--gc-sections -Wl,--strip-all -static -Wl,--no-undefined -static -static-libgcc -static-libstdc++ -static
touch ../lv2_ttl_generator
make[1]: Leaving directory '/home/chris/work/ykchorus/dpf/utils/lv2-ttl-generator'
dpf/utils/generate-ttl.sh: line 38: dpf/utils/lv2_ttl_generator.exe: No such file or directory
make: *** [Makefile:125: gen] Error 127
```

I think this bug was introduced in 648452a, because only the code path for macOS and Posix was adapted to the changes.
