### PR TITLE
[WIP] VST3: Fix incorrect MIDI input values for CC and Note On/Off

### DIFF
--- a/distrho/src/DistrhoPluginVST3.cpp
+++ b/distrho/src/DistrhoPluginVST3.cpp
@@ -359,14 +359,14 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x90 | (eventStorage.noteOn.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOn.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOn.velocity / 0.0078125)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.noteOn.velocity * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 case NoteOff:
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x80 | (eventStorage.noteOff.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOff.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOff.velocity / 0.0078125)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.noteOff.velocity * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 /* TODO
@@ -377,7 +377,7 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0xA0 | (eventStorage.polyPressure.channel & 0xf);
                     midiEvent.data[1] = eventStorage.polyPressure.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.polyPressure.pressure / 0.0078125)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.polyPressure.pressure * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 case CC_Normal:
@@ -469,7 +469,7 @@ class PluginVst3
             {
             case 128:
                 eventStorage.type = CC_ChannelPressure;
-                eventStorage.midi[1] = std::max(0, std::min(127, (int)(normalized / 0.0078125)));
+                eventStorage.midi[1] = std::max(0, std::min(127, (int)std::round(normalized * 127)));
                 eventStorage.midi[2] = 0;
                 break;
             case 129:
@@ -480,7 +480,7 @@ class PluginVst3
             default:
                 eventStorage.type = CC_Normal;
                 eventStorage.midi[1] = cc;
-                eventStorage.midi[2] = std::max(0, std::min(127, (int)(normalized / 0.0078125)));
+                eventStorage.midi[2] = std::max(0, std::min(127, (int)std::round(normalized * 127)));
                 break;
             }
 

--- a/distrho/src/DistrhoPluginVST3.cpp
+++ b/distrho/src/DistrhoPluginVST3.cpp
@@ -359,14 +359,14 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x90 | (eventStorage.noteOn.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOn.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.noteOn.velocity * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, d_roundToIntPositive(eventStorage.noteOn.velocity * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 case NoteOff:
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x80 | (eventStorage.noteOff.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOff.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.noteOff.velocity * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, d_roundToIntPositive(eventStorage.noteOff.velocity * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 /* TODO
@@ -377,7 +377,7 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0xA0 | (eventStorage.polyPressure.channel & 0xf);
                     midiEvent.data[1] = eventStorage.polyPressure.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)std::round(eventStorage.polyPressure.pressure * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, d_roundToIntPositive(eventStorage.polyPressure.pressure * 127)));
                     midiEvent.data[3] = 0;
                     break;
                 case CC_Normal:
@@ -469,7 +469,7 @@ class PluginVst3
             {
             case 128:
                 eventStorage.type = CC_ChannelPressure;
-                eventStorage.midi[1] = std::max(0, std::min(127, (int)std::round(normalized * 127)));
+                eventStorage.midi[1] = std::max(0, std::min(127, d_roundToIntPositive(normalized * 127)));
                 eventStorage.midi[2] = 0;
                 break;
             case 129:
@@ -480,7 +480,7 @@ class PluginVst3
             default:
                 eventStorage.type = CC_Normal;
                 eventStorage.midi[1] = cc;
-                eventStorage.midi[2] = std::max(0, std::min(127, (int)std::round(normalized * 127)));
+                eventStorage.midi[2] = std::max(0, std::min(127, d_roundToIntPositive(normalized * 127)));
                 break;
             }
 

--- a/distrho/src/DistrhoPluginVST3.cpp
+++ b/distrho/src/DistrhoPluginVST3.cpp
@@ -359,14 +359,14 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x90 | (eventStorage.noteOn.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOn.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOn.velocity * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOn.velocity / 0.0078125)));
                     midiEvent.data[3] = 0;
                     break;
                 case NoteOff:
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0x80 | (eventStorage.noteOff.channel & 0xf);
                     midiEvent.data[1] = eventStorage.noteOff.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOff.velocity * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.noteOff.velocity / 0.0078125)));
                     midiEvent.data[3] = 0;
                     break;
                 /* TODO
@@ -377,7 +377,7 @@ class PluginVst3
                     midiEvent.size = 3;
                     midiEvent.data[0] = 0xA0 | (eventStorage.polyPressure.channel & 0xf);
                     midiEvent.data[1] = eventStorage.polyPressure.pitch;
-                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.polyPressure.pressure * 127)));
+                    midiEvent.data[2] = std::max(0, std::min(127, (int)(eventStorage.polyPressure.pressure / 0.0078125)));
                     midiEvent.data[3] = 0;
                     break;
                 case CC_Normal:
@@ -469,7 +469,7 @@ class PluginVst3
             {
             case 128:
                 eventStorage.type = CC_ChannelPressure;
-                eventStorage.midi[1] = std::max(0, std::min(127, (int)(normalized * 127)));
+                eventStorage.midi[1] = std::max(0, std::min(127, (int)(normalized / 0.0078125)));
                 eventStorage.midi[2] = 0;
                 break;
             case 129:
@@ -480,7 +480,7 @@ class PluginVst3
             default:
                 eventStorage.type = CC_Normal;
                 eventStorage.midi[1] = cc;
-                eventStorage.midi[2] = std::max(0, std::min(127, (int)(normalized * 127)));
+                eventStorage.midi[2] = std::max(0, std::min(127, (int)(normalized / 0.0078125)));
                 break;
             }
 

--- a/examples/MidiThrough/MidiThroughExamplePlugin.cpp
+++ b/examples/MidiThrough/MidiThroughExamplePlugin.cpp
@@ -101,15 +101,7 @@ protected:
              const MidiEvent* midiEvents, uint32_t midiEventCount) override
     {
         for (uint32_t i=0; i<midiEventCount; ++i)
-        {
-            uint8_t b0 = midiEvents[i].data[0]; // status + channel
-            uint8_t b0_status = b0 & 0xF0;
-            uint8_t b0_channel = b0 & 0x0F;
-            uint8_t b1 = midiEvents[i].data[1]; // note
-            uint8_t b2 = midiEvents[i].data[2]; // velocity
-            d_stdout("MIDI in 0x%x (status: 0x%x, channel: 0x%x) %d %d", b0, b0_status, b0_channel, b1, b2);
             writeMidiEvent(midiEvents[i]);
-        }
     }
 
     // -------------------------------------------------------------------------------------------------------

--- a/examples/MidiThrough/MidiThroughExamplePlugin.cpp
+++ b/examples/MidiThrough/MidiThroughExamplePlugin.cpp
@@ -101,7 +101,15 @@ protected:
              const MidiEvent* midiEvents, uint32_t midiEventCount) override
     {
         for (uint32_t i=0; i<midiEventCount; ++i)
+        {
+            uint8_t b0 = midiEvents[i].data[0]; // status + channel
+            uint8_t b0_status = b0 & 0xF0;
+            uint8_t b0_channel = b0 & 0x0F;
+            uint8_t b1 = midiEvents[i].data[1]; // note
+            uint8_t b2 = midiEvents[i].data[2]; // velocity
+            d_stdout("MIDI in 0x%x (status: 0x%x, channel: 0x%x) %d %d", b0, b0_status, b0_channel, b1, b2);
             writeMidiEvent(midiEvents[i]);
+        }
     }
 
     // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Here's an approach to fixing the issue. I couldn't figure out where the normalized value comes from but the issue is probably there because for a received value of 1, it's mapped to 0.007874 which is 1.0/127 and not 1.0/128 as it should be, at least from what I can gather.

https://github.com/DISTRHO/DPF/compare/main...Simon-L:DPF:fix-vst3-midi-values?expand=1#diff-74e172a4a71aa46c34a85756971124027fc8807d094f6cf7f339335cca676234R1994 This line looked suspicious as well but it doesn't seem to be executed at any moment when receiving CC or Note On/Off

Given the current normalized input, mutliply by 127 would give wrong result for some input values, dividing by 0.0078125, which is 1.0/128, fixes this.