### PR TITLE
add double click event to ImageBaseKnob

### DIFF
--- a/dgl/ImageBaseWidgets.hpp
+++ b/dgl/ImageBaseWidgets.hpp
@@ -138,6 +138,7 @@ public:
         virtual void imageKnobDragStarted(ImageBaseKnob* imageKnob) = 0;
         virtual void imageKnobDragFinished(ImageBaseKnob* imageKnob) = 0;
         virtual void imageKnobValueChanged(ImageBaseKnob* imageKnob, float value) = 0;
+        virtual void imageKnobDoubleClicked(ImageBaseKnob* imageKnob) = 0;
     };
 
     explicit ImageBaseKnob(Widget* parentWidget, const ImageType& image, Orientation orientation = Vertical) noexcept;

--- a/dgl/src/ImageBaseWidgets.cpp
+++ b/dgl/src/ImageBaseWidgets.cpp
@@ -316,6 +316,13 @@ struct ImageBaseKnob<ImageType>::PrivateData : public KnobEventHandler::Callback
                 callback->imageKnobValueChanged(imageKnob, value);
     }
 
+    void knobDoubleClicked(SubWidget* const widget) override
+    {
+        if (callback != nullptr)
+            if (ImageBaseKnob* const imageKnob = dynamic_cast<ImageBaseKnob*>(widget))
+                callback->imageKnobDoubleClicked(imageKnob);
+    }
+
     // implemented independently per graphics backend
     void init();
     void cleanup();


### PR DESCRIPTION
Since a double click event was already implemented in the backend, I simply added it to the ImageBaseKnob for easy subscription in the plugin's UI class. Useful for resetting a knob to its default value for example. 