### PR TITLE
add default value getter

### DIFF
--- a/dgl/EventHandlers.hpp
+++ b/dgl/EventHandlers.hpp
@@ -136,6 +136,8 @@ public:
     // NOTE: value is assumed to be scaled if using log
     void setDefault(float def) noexcept;
 
+    float getDefault() noexcept;
+
     // NOTE: value is assumed to be scaled if using log
     void setRange(float min, float max) noexcept;
 

--- a/dgl/EventHandlers.hpp
+++ b/dgl/EventHandlers.hpp
@@ -133,10 +133,10 @@ public:
     // returns 0-1 ranged value, already with log scale as needed
     float getNormalizedValue() const noexcept;
 
+    float getDefault() const noexcept;
+
     // NOTE: value is assumed to be scaled if using log
     void setDefault(float def) noexcept;
-
-    float getDefault() noexcept;
 
     // NOTE: value is assumed to be scaled if using log
     void setRange(float min, float max) noexcept;

--- a/dgl/src/EventHandlers.cpp
+++ b/dgl/src/EventHandlers.cpp
@@ -618,15 +618,15 @@ float KnobEventHandler::getNormalizedValue() const noexcept
     return pData->getNormalizedValue();
 }
 
+float KnobEventHandler::getDefault() const noexcept
+{
+    return pData->valueDef;
+}
+
 void KnobEventHandler::setDefault(const float def) noexcept
 {
     pData->valueDef = def;
     pData->usingDefault = true;
-}
-
-float KnobEventHandler::getDefault() noexcept
-{
-    return pData->valueDef;
 }
 
 void KnobEventHandler::setRange(const float min, const float max) noexcept

--- a/dgl/src/EventHandlers.cpp
+++ b/dgl/src/EventHandlers.cpp
@@ -624,6 +624,11 @@ void KnobEventHandler::setDefault(const float def) noexcept
     pData->usingDefault = true;
 }
 
+float KnobEventHandler::getDefault() noexcept
+{
+    return pData->valueDef;
+}
+
 void KnobEventHandler::setRange(const float min, const float max) noexcept
 {
     pData->setRange(min, max);


### PR DESCRIPTION
Add a getter to retrieve a knob's default value. Useful when having to reset a knob to its default state. 