### PR TITLE
Add khronos to gitignore in order to avoid "modified" git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 docs/
 utils/lv2_ttl_generator
 utils/lv2_ttl_generator.dSYM/
+
+khronos


### PR DESCRIPTION
I use submodule to include DPF to my project.
DPF clones khronos in its directory, but it causes "modified" status on git.
This PR adds khronos to gitignore to avoid that status.