### PR TITLE
Reintroduce std::string_view constructor for String

### DIFF
--- a/distrho/extra/String.hpp
+++ b/distrho/extra/String.hpp
@@ -22,6 +22,10 @@
 
 #include <algorithm>
 
+#if __cplusplus >= 201703L
+# include <string_view>
+#endif
+
 START_NAMESPACE_DISTRHO
 
 // -----------------------------------------------------------------------
@@ -86,6 +90,16 @@ public:
     {
         _dup(strBuf);
     }
+
+   #if __cplusplus >= 201703L
+    /*
+     * std::string_view, not requiring a null terminator
+     */
+    explicit String(const std::string_view& strView) noexcept
+        : fBuffer(const_cast<char*>(strView.data())),
+          fBufferLen(strView.size()),
+          fBufferAlloc(false) {}
+   #endif
 
     /*
      * Integer.


### PR DESCRIPTION
This reintroduces the `std::string_view` constructor for String which was removed in 01aca7649c1a3a5ee20a47c5ecd3cb2e29395f89. I agree that the constexpr portion of the functionality was largely broken, so this reintroduction does not declare anything constexpr.