### PR TITLE
Add missing DGL_NAMESPACE qualifier

### DIFF
--- a/distrho/src/DistrhoUIInternal.hpp
+++ b/distrho/src/DistrhoUIInternal.hpp
@@ -267,12 +267,12 @@ public:
         uiData->app.repaintIfNeeeded();
     }
 
-    void addIdleCallbackForNativeIdle(IdleCallback* const cb, const uint timerFrequencyInMs)
+    void addIdleCallbackForNativeIdle(DGL_NAMESPACE::IdleCallback* const cb, const uint timerFrequencyInMs)
     {
         uiData->window->addIdleCallback(cb, timerFrequencyInMs);
     }
 
-    void removeIdleCallbackForNativeIdle(IdleCallback* const cb)
+    void removeIdleCallbackForNativeIdle(DGL_NAMESPACE::IdleCallback* const cb)
     {
         uiData->window->removeIdleCallback(cb);
     }


### PR DESCRIPTION
Fixes a build failure on MSVC when building with `DONT_SET_USING_DGL_NAMESPACE`:

    distrho\src\DistrhoUIInternal.hpp(270,39): error C2061: syntax error: identifier 'IdleCallback'
      (compiling source file 'distrho/DistrhoPluginMain.cpp')
