### PR TITLE
Updated setState on AU to allow arbitrary key-value pairs on macOS

### DIFF
--- a/distrho/src/DistrhoPluginAU.cpp
+++ b/distrho/src/DistrhoPluginAU.cpp
@@ -1651,25 +1651,23 @@ public:
            #if DISTRHO_PLUGIN_WANT_STATE
             DISTRHO_SAFE_ASSERT_UINT_RETURN(inElement < fStateCount, inElement, kAudioUnitErr_InvalidElement);
             {
-                const CFStringRef valueRef = *static_cast<const CFStringRef*>(inData);
-                DISTRHO_SAFE_ASSERT_RETURN(valueRef != nullptr && CFGetTypeID(valueRef) == CFStringGetTypeID(),
+                const CFDictionaryRef dictRef = *static_cast<const CFDictionaryRef*>(inData);
+                DISTRHO_SAFE_ASSERT_RETURN(dictRef != nullptr && CFGetTypeID(dictRef) == CFDictionaryGetTypeID(),
                                            kAudioUnitErr_InvalidPropertyValue);
+                const void * keyArr;
+                const void * valueArr;
+                CFDictionaryGetKeysAndValues(dictRef, &keyArr, &valueArr);
 
-                const CFIndex valueLen = CFStringGetLength(valueRef);
-                char* const value = static_cast<char*>(std::malloc(valueLen + 1));
-                DISTRHO_SAFE_ASSERT_RETURN(value != nullptr, kAudio_ParamError);
-                DISTRHO_SAFE_ASSERT_RETURN(CFStringGetCString(valueRef, value, valueLen + 1, kCFStringEncodingUTF8),
-                                           kAudioUnitErr_InvalidPropertyValue);
+                const char* cKey = [keyArr UTF8String];
+                const char* cValue = [valueArr UTF8String];
 
-                const String& key(fPlugin.getStateKey(inElement));
+                const String stringKey(cKey);
 
                 // save this key as needed
-                if (fPlugin.wantStateKey(key))
-                    fStateMap[key] = value;
+                if (fPlugin.wantStateKey(stringKey))
+                    fStateMap[stringKey] = cValue;
 
-                fPlugin.setState(key, value);
-
-                std::free(value);
+                fPlugin.setState(stringKey, cValue);
             }
             return noErr;
            #else

--- a/distrho/src/DistrhoUIAU.mm
+++ b/distrho/src/DistrhoUIAU.mm
@@ -34,8 +34,6 @@
 # error DISTRHO_PLUGIN_UNIQUE_ID undefined!
 #endif
 
-#include <iostream>
-
 START_NAMESPACE_DISTRHO
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/distrho/src/DistrhoUIAU.mm
+++ b/distrho/src/DistrhoUIAU.mm
@@ -34,6 +34,8 @@
 # error DISTRHO_PLUGIN_UNIQUE_ID undefined!
 #endif
 
+#include <iostream>
+
 START_NAMESPACE_DISTRHO
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -322,14 +324,23 @@ private:
    #if DISTRHO_PLUGIN_WANT_STATE
     void setState(const char* const key, const char* const value)
     {
-        const std::vector<String>::iterator it = std::find(fStateKeys.begin(), fStateKeys.end(), key);
-        DISTRHO_SAFE_ASSERT_RETURN(it != fStateKeys.end(),);
-
-        if (const CFStringRef valueRef = CFStringCreateWithCString(nullptr, value, kCFStringEncodingUTF8))
+        if (const CFStringRef keyRef = CFStringCreateWithCString((CFAllocatorRef )NULL,key,kCFStringEncodingUTF8))
         {
-            const uint32_t index = it - fStateKeys.begin();
-            AudioUnitSetProperty(fComponent, 'DPFs', kAudioUnitScope_Global, index, &valueRef, sizeof(CFStringRef));
-            CFRelease(valueRef);
+            if (const CFStringRef valueRef = CFStringCreateWithCString(( CFAllocatorRef )NULL,
+                value,kCFStringEncodingUTF8))
+            {
+                CFTypeRef keyArrayRef[1] = {keyRef};
+                CFTypeRef valueArrayRef[1] = {valueRef};
+
+                CFDictionaryRef dictRef = CFDictionaryCreate((CFAllocatorRef)NULL,( const void ** )keyArrayRef,
+                    ( const void ** )valueArrayRef, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+                AudioUnitSetProperty(fComponent, 'DPFs', kAudioUnitScope_Global, 0, &dictRef, sizeof(dictRef));
+
+                CFRelease(keyRef);
+                CFRelease(valueRef);
+                CFRelease(dictRef);
+            }
         }
     }
 


### PR DESCRIPTION
Should fix #494 

Confirmed working with the States plugin example on macOS 15.3 using Logic