### PR TITLE
valgrind: Add malloc / memalign suppression for real 1d fftw

### DIFF
--- a/utils/valgrind-dpf.supp
+++ b/utils/valgrind-dpf.supp
@@ -96,8 +96,9 @@
 {
    leak in fftw plan
    Memcheck:Leak
-   fun:memalign
+   fun:malloc
    fun:fftwf_malloc_plain
+   ...
    fun:fftwf_mkapiplan
    fun:fftwf_plan_many_r2r
    fun:fftwf_plan_r2r
@@ -109,8 +110,7 @@
    Memcheck:Leak
    fun:memalign
    fun:fftwf_malloc_plain
-   fun:fftwf_mkplanner
-   fun:fftwf_the_planner
+   ...
    fun:fftwf_mkapiplan
    fun:fftwf_plan_many_r2r
    fun:fftwf_plan_r2r


### PR DESCRIPTION
Because: Testing on actual CI showed different results than locally. See https://github.com/zamaudio/zam-plugins/actions/runs/15036703697/job/42259708310