### PR TITLE
Fixed USE_FILEBROWSER typo in makefile

### DIFF
--- a/Makefile.base.mk
+++ b/Makefile.base.mk
@@ -484,7 +484,7 @@ endif
 
 else
 
-ifeq ($(USE_FILEBROWSER)$(HAVE_DBUS),truetrue)
+ifeq ($(USE_FILE_BROWSER)$(HAVE_DBUS),truetrue)
 DGL_FLAGS       += $(shell $(PKG_CONFIG) --cflags dbus-1) -DHAVE_DBUS
 DGL_SYSTEM_LIBS += $(shell $(PKG_CONFIG) --libs dbus-1)
 endif


### PR DESCRIPTION
USE_FILE_BROWSER wasn't working for me with save dialogs on linux. Changing this allowed the save dialog to work, the dbus implementation seems to have the working save dialog implementation unlike the x11 route.

Looks like setting USE_FILE_BROWSER doesn't enable the correct dbus flags because its checking for USE_FILEBROWSER instead

Your makefile also implies this was a typo
```
ifeq ($(USE_FILEBROWSER),true)
$(error typo detected use USE_FILE_BROWSER instead of USE_FILEBROWSER)
endif
```
