### PR TITLE
Fix KnobEventHandler motion drag with log scale

### DIFF
--- a/dgl/src/EventHandlers.cpp
+++ b/dgl/src/EventHandlers.cpp
@@ -492,7 +492,8 @@ struct KnobEventHandler::PrivateData {
             return true;
 
         const float divisor = (ev.mod & kModifierControl) ? accel * 10.f : accel;
-        valueTmp += (maximum - minimum) / divisor * static_cast<float>(movDiff);
+        valueTmp = (usingLog ? invlogscale(valueTmp) : valueTmp)
+                 + (maximum - minimum) / divisor * static_cast<float>(movDiff);
 
         if (usingLog)
             valueTmp = logscale(valueTmp);


### PR DESCRIPTION
Fixes #388.

`motionEvent()` added the linear mouse delta directly to `valueTmp` and then applied `logscale()` once. But `valueTmp` is stored in log-scaled space when `usingLog` is set (that's what `logscale()` at the end of each call produces), so adding a linear delta to it and then log-scaling again double-transforms the value — which is why dragging a log-scale knob stayed stuck near the minimum.

The fix converts `valueTmp` back to linear space via `invlogscale()` before adding the delta, exactly like the already-correct `scrollEvent()` a few lines below in the same file (mouse wheel already worked correctly per the original report, and this makes `motionEvent()` consistent with it).

Verification:
- Wrote a standalone C++ program reproducing the exact `logscale`/`invlogscale` formulas and both the old and new `motionEvent` computations. Simulating 5 drag steps of +1 linear unit each on a log-scale knob (range 1–100, starting at linear value 10): the old code converges to ~2.05 (confirming the reported bug — stuck near the minimum), the new code correctly reaches ~15.0 and matches `scrollEvent`'s math bit-for-bit.
- Built `dgl` with the Cairo backend (`make -C dgl cairo`) — compiles cleanly.
- Built the `CairoUI` example plugin across all formats (CLAP, DSSI, JACK standalone, LV2, VST2, VST3, AU) — all succeed.
- Wasn't able to do a live/visual mouse-drag test in this environment (no display server for interactive GUI testing here), so flagging that the fix is verified mathematically and via successful builds, not an actual on-screen drag.

Small part of this fix (working through the log-scale round-trip math above) was done with the help of Claude Code.